### PR TITLE
feat: enabled swagger

### DIFF
--- a/back/package.json
+++ b/back/package.json
@@ -26,6 +26,7 @@
     "@nestjs/jwt": "^10.2.0",
     "@nestjs/passport": "^10.0.3",
     "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/swagger": "^7.3.0",
     "@nestjs/typeorm": "^10.0.2",
     "mysql2": "^3.9.1",
     "passport-jwt": "^4.0.1",

--- a/back/pnpm-lock.yaml
+++ b/back/pnpm-lock.yaml
@@ -23,6 +23,9 @@ dependencies:
   '@nestjs/platform-express':
     specifier: ^10.0.0
     version: 10.3.2(@nestjs/common@10.3.2)(@nestjs/core@10.3.2)
+  '@nestjs/swagger':
+    specifier: ^7.3.0
+    version: 7.3.0(@nestjs/common@10.3.2)(@nestjs/core@10.3.2)(reflect-metadata@0.1.14)
   '@nestjs/typeorm':
     specifier: ^10.0.2
     version: 10.0.2(@nestjs/common@10.3.2)(@nestjs/core@10.3.2)(reflect-metadata@0.1.14)(rxjs@7.8.1)(typeorm@0.3.20)
@@ -860,6 +863,10 @@ packages:
     resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
     engines: {node: '>=8'}
 
+  /@microsoft/tsdoc@0.14.2:
+    resolution: {integrity: sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug==}
+    dev: false
+
   /@nestjs/cli@10.3.2:
     resolution: {integrity: sha512-aWmD1GLluWrbuC4a1Iz/XBk5p74Uj6nIVZj6Ov03JbTfgtWqGFLtXuMetvzMiHxfrHehx/myt2iKAPRhKdZvTg==}
     engines: {node: '>= 16.14'}
@@ -975,6 +982,23 @@ packages:
       jsonwebtoken: 9.0.2
     dev: false
 
+  /@nestjs/mapped-types@2.0.5(@nestjs/common@10.3.2)(reflect-metadata@0.1.14):
+    resolution: {integrity: sha512-bSJv4pd6EY99NX9CjBIyn4TVDoSit82DUZlL4I3bqNfy5Gt+gXTa86i3I/i0iIV9P4hntcGM5GyO+FhZAhxtyg==}
+    peerDependencies:
+      '@nestjs/common': ^8.0.0 || ^9.0.0 || ^10.0.0
+      class-transformer: ^0.4.0 || ^0.5.0
+      class-validator: ^0.13.0 || ^0.14.0
+      reflect-metadata: ^0.1.12 || ^0.2.0
+    peerDependenciesMeta:
+      class-transformer:
+        optional: true
+      class-validator:
+        optional: true
+    dependencies:
+      '@nestjs/common': 10.3.2(reflect-metadata@0.1.14)(rxjs@7.8.1)
+      reflect-metadata: 0.1.14
+    dev: false
+
   /@nestjs/passport@10.0.3(@nestjs/common@10.3.2)(passport@0.7.0):
     resolution: {integrity: sha512-znJ9Y4S8ZDVY+j4doWAJ8EuuVO7SkQN3yOBmzxbGaXbvcSwFDAdGJ+OMCg52NdzIO4tQoN4pYKx8W6M0ArfFRQ==}
     peerDependencies:
@@ -1015,6 +1039,34 @@ packages:
     transitivePeerDependencies:
       - chokidar
     dev: true
+
+  /@nestjs/swagger@7.3.0(@nestjs/common@10.3.2)(@nestjs/core@10.3.2)(reflect-metadata@0.1.14):
+    resolution: {integrity: sha512-zLkfKZ+ioYsIZ3dfv7Bj8YHnZMNAGWFUmx2ZDuLp/fBE4P8BSjB7hldzDueFXsmwaPL90v7lgyd82P+s7KME1Q==}
+    peerDependencies:
+      '@fastify/static': ^6.0.0 || ^7.0.0
+      '@nestjs/common': ^9.0.0 || ^10.0.0
+      '@nestjs/core': ^9.0.0 || ^10.0.0
+      class-transformer: '*'
+      class-validator: '*'
+      reflect-metadata: ^0.1.12 || ^0.2.0
+    peerDependenciesMeta:
+      '@fastify/static':
+        optional: true
+      class-transformer:
+        optional: true
+      class-validator:
+        optional: true
+    dependencies:
+      '@microsoft/tsdoc': 0.14.2
+      '@nestjs/common': 10.3.2(reflect-metadata@0.1.14)(rxjs@7.8.1)
+      '@nestjs/core': 10.3.2(@nestjs/common@10.3.2)(@nestjs/platform-express@10.3.2)(reflect-metadata@0.1.14)(rxjs@7.8.1)
+      '@nestjs/mapped-types': 2.0.5(@nestjs/common@10.3.2)(reflect-metadata@0.1.14)
+      js-yaml: 4.1.0
+      lodash: 4.17.21
+      path-to-regexp: 3.2.0
+      reflect-metadata: 0.1.14
+      swagger-ui-dist: 5.11.2
+    dev: false
 
   /@nestjs/testing@10.3.2(@nestjs/common@10.3.2)(@nestjs/core@10.3.2)(@nestjs/platform-express@10.3.2):
     resolution: {integrity: sha512-jetqEPqOPuxmhBinkizmJQg4UZ2IRFrUoMrBDSgg0ogQClokKjnLgkoC5de+Jfm2kub/VpqorHB0me8cCr5jEQ==}
@@ -1717,7 +1769,6 @@ packages:
 
   /argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
-    dev: true
 
   /array-flatten@1.1.1:
     resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
@@ -3756,7 +3807,6 @@ packages:
     hasBin: true
     dependencies:
       argparse: 2.0.1
-    dev: true
 
   /jsesc@2.5.2:
     resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==}
@@ -4962,6 +5012,10 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
     dev: true
+
+  /swagger-ui-dist@5.11.2:
+    resolution: {integrity: sha512-jQG0cRgJNMZ7aCoiFofnoojeSaa/+KgWaDlfgs8QN+BXoGMpxeMVY5OEnjq4OlNvF3yjftO8c9GRAgcHlO+u7A==}
+    dev: false
 
   /symbol-observable@4.0.0:
     resolution: {integrity: sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==}

--- a/back/src/main.ts
+++ b/back/src/main.ts
@@ -1,5 +1,6 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, {
@@ -9,6 +10,13 @@ async function bootstrap() {
       credentials: true,
     },
   });
-  await app.listen(5000);
+  const config = new DocumentBuilder()
+    .setTitle('Hypertube API')
+    .setDescription('API Documentation for Hypertube.')
+    .setVersion('1.0')
+    .build();
+  const document = SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup('api', app, document);
+  await app.listen(5050);
 }
 bootstrap();

--- a/back/src/main.ts
+++ b/back/src/main.ts
@@ -17,6 +17,6 @@ async function bootstrap() {
     .build();
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('api', app, document);
-  await app.listen(5050);
+  await app.listen(5000);
 }
 bootstrap();

--- a/back/src/user/dto/user.dto.ts
+++ b/back/src/user/dto/user.dto.ts
@@ -1,0 +1,3 @@
+import { User } from 'src/user/user.entity';
+
+export class UserDto extends User { }

--- a/back/src/user/user.controller.ts
+++ b/back/src/user/user.controller.ts
@@ -14,6 +14,7 @@ import { AuthService } from 'src/auth/auth.service';
 import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { UserDto } from './dto/user.dto';
 
+@ApiTags('User')
 @Controller('users')
 export class UserController {
   constructor(

--- a/back/src/user/user.controller.ts
+++ b/back/src/user/user.controller.ts
@@ -11,19 +11,24 @@ import {
 import { UserService } from './user.service';
 import { User } from './user.entity';
 import { AuthService } from 'src/auth/auth.service';
+import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { UserDto } from './dto/user.dto';
 
 @Controller('users')
 export class UserController {
   constructor(
     private authService: AuthService,
     private readonly userService: UserService,
-  ) {}
+  ) { }
 
+  @ApiOperation({ summary: '전체 유저 확인' })
   @Get()
   async findAll(): Promise<User[]> {
     return this.userService.findAll();
   }
 
+  @ApiOkResponse({ type: UserDto })
+  @ApiOperation({ summary: '유저 확인' })
   @Get(':id')
   async findOne(@Param('id') id: number): Promise<User> {
     return this.userService.findOne(id);

--- a/back/src/user/user.entity.ts
+++ b/back/src/user/user.entity.ts
@@ -1,22 +1,52 @@
 import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+import { ApiProperty } from '@nestjs/swagger';
 
-@Entity()
+@Entity('user')
 export class User {
+  @ApiProperty({
+    description: '유저 DB테이블 ID번호',
+    example: 1,
+  })
   @PrimaryGeneratedColumn()
   id: number;
 
-  @Column()
+  @ApiProperty({
+    description: '이름 (First Name)',
+    example: 'marvin',
+    required: true,
+  })
+  @Column({ type: 'varchar', name: 'lastName', length: 20, unique: true })
   firstName: string;
 
-  @Column()
+  @ApiProperty({
+    description: '성 (Last Name)',
+    example: 'gaye',
+    required: true,
+  })
+  @Column({ type: 'varchar', name: 'firstName', length: 20, unique: true })
   lastName: string;
 
+  // @ApiProperty({
+  //   description: '유저 아이디',
+  //   example: 'marvin',
+  //   required: true,
+  // })
   @Column({ type: 'varchar', name: 'username', length: 20, unique: true })
   username: string;
 
+  @ApiProperty({
+    description: '이메일 주소',
+    example: 'marvin@student.42.fr',
+    required: true,
+  })
   @Column({ type: 'varchar', name: 'email', length: 40, unique: true })
   email: string;
 
-  @Column()
+  // @ApiProperty({
+  //   description: '비밀번호',
+  //   example: 'marvin',
+  //   required: true,
+  // })
+  @Column({ type: 'varchar', name: 'firstName', length: 20, unique: true })
   password: string;
 }


### PR DESCRIPTION
Swagger 모듈을 추가하여 api 문서를 바로 확인하실 수 있습니다.

코드에도 나와있지만 main.ts 에서 { DocumentBuilder, SwaggerModule }을 불러 온 이후에 DocumentBuilder 객체 생성 -> swaggermodule에서 document 생성, setup 진행하면 바로 사용합니다.

http://localhost:5000/api 로 연결하시면 바로 확인가능하고 추후에 경로 수정 가능합니다. 

swagger 확인용으로 UserDTO 클래스도 만들어 놓았습니다.

@ApiOperation, @ApiOkResponse 데코레이터를 잘 설정 해놓으면 swagger위에서도 바로 req/res 테스트를 해 볼수 있으니 한번 확인 해보시는걸 추천드립니다.
그리고 swagger 가 생성해 놓은것들 두루두루 보시면 좋을것 같네요

![image](https://github.com/woolimi/hypertube/assets/46742040/acc7a9cf-dd39-4009-8b61-39ba5bbfabeb)