### PR TITLE
refactor: generate globally used validators for profile and account info

### DIFF
--- a/front/composables/useValidator.ts
+++ b/front/composables/useValidator.ts
@@ -90,10 +90,10 @@ export const useValidator = () => {
 
   const lastNameValidator = (
     dirty: ComputedRef<boolean>,
-    password: ComputedRef<string>,
+    lastName: ComputedRef<string>,
     t: any, //I18n
   ) => {
-    return validator(dirty, password, [
+    return validator(dirty, lastName, [
       requiredRule(t("Error.REQUIRED", { value: t("_Global.lastName") })),
       minLengthRule(
         t("Error.MIN_LENGTH", {

--- a/front/composables/useValidator.ts
+++ b/front/composables/useValidator.ts
@@ -70,10 +70,9 @@ export const useValidator = () => {
     dirty: ComputedRef<boolean>,
     firstName: ComputedRef<string>,
     t: any, //I18n
-    pageModule: any,
   ) => {
     return validator(dirty, firstName, [
-      requiredRule(t("Error.REQUIRED", { value: pageModule })),
+      requiredRule(t("Error.REQUIRED", { value: t("_Global.firstName") })),
       minLengthRule(
         t("Error.MIN_LENGTH", {
           value: t("_Global.firstName"),
@@ -91,14 +90,26 @@ export const useValidator = () => {
 
   const lastNameValidator = (
     dirty: ComputedRef<boolean>,
-    lastName: ComputedRef<string>,
+    password: ComputedRef<string>,
     t: any, //I18n
   ) => {
-    return validator(dirty, lastName, [
-      requiredRule(t("Error.REQUIRED", { value: t("_Global.password") })),
-      passwordRule(t("Error.INVALID_PASSWORD")),
+    return validator(dirty, password, [
+      requiredRule(t("Error.REQUIRED", { value: t("_Global.lastName") })),
+      minLengthRule(
+        t("Error.MIN_LENGTH", {
+          value: t("_Global.lastName"),
+          length: DEFAULT_MIN,
+        }),
+      ),
+      maxLengthRule(
+        t("Error.MAX_LENGTH", {
+          value: t("_Global.lastName"),
+          length: DEFAULT_MAX,
+        }),
+      ),
     ]);
   };
+
   const emailValidator = (
     dirty: ComputedRef<boolean>,
     email: ComputedRef<string>,
@@ -112,23 +123,12 @@ export const useValidator = () => {
 
   const passwordValidator = (
     dirty: ComputedRef<boolean>,
-    password: ComputedRef<string>,
+    lastName: ComputedRef<string>,
     t: any, //I18n
   ) => {
-    return validator(dirty, password, [
+    return validator(dirty, lastName, [
       requiredRule(t("Error.REQUIRED", { value: t("_Global.password") })),
-      minLengthRule(
-        t("Error.MIN_LENGTH", {
-          value: t("_Global.password"),
-          length: DEFAULT_MIN,
-        }),
-      ),
-      maxLengthRule(
-        t("Error.MAX_LENGTH", {
-          value: t("_Global.password"),
-          length: DEFAULT_MAX,
-        }),
-      ),
+      passwordRule(t("Error.INVALID_PASSWORD")),
     ]);
   };
 

--- a/front/composables/useValidator.ts
+++ b/front/composables/useValidator.ts
@@ -44,8 +44,101 @@ export const useValidator = () => {
     return (value: string) => (!value.length ? errorMessages : undefined);
   };
 
+  const usernameValidator = (
+    dirty: ComputedRef<boolean>,
+    username: ComputedRef<string>,
+    t: any, //I18n
+  ) => {
+    return validator(dirty, username, [
+      requiredRule(t("Error.REQUIRED", { value: t("_Global.username") })),
+      minLengthRule(
+        t("Error.MIN_LENGTH", {
+          value: t("_Global.username"),
+          length: DEFAULT_MIN,
+        }),
+      ),
+      maxLengthRule(
+        t("Error.MAX_LENGTH", {
+          value: t("_Global.username"),
+          length: DEFAULT_MAX,
+        }),
+      ),
+    ]);
+  };
+
+  const firstNameValidator = (
+    dirty: ComputedRef<boolean>,
+    firstName: ComputedRef<string>,
+    t: any, //I18n
+    pageModule: any,
+  ) => {
+    return validator(dirty, firstName, [
+      requiredRule(t("Error.REQUIRED", { value: pageModule })),
+      minLengthRule(
+        t("Error.MIN_LENGTH", {
+          value: t("_Global.firstName"),
+          length: DEFAULT_MIN,
+        }),
+      ),
+      maxLengthRule(
+        t("Error.MAX_LENGTH", {
+          value: t("_Global.firstName"),
+          length: DEFAULT_MAX,
+        }),
+      ),
+    ]);
+  };
+
+  const lastNameValidator = (
+    dirty: ComputedRef<boolean>,
+    lastName: ComputedRef<string>,
+    t: any, //I18n
+  ) => {
+    return validator(dirty, lastName, [
+      requiredRule(t("Error.REQUIRED", { value: t("_Global.password") })),
+      passwordRule(t("Error.INVALID_PASSWORD")),
+    ]);
+  };
+  const emailValidator = (
+    dirty: ComputedRef<boolean>,
+    email: ComputedRef<string>,
+    t: any, //I18n
+  ) => {
+    return validator(dirty, email, [
+      requiredRule(t("Error.REQUIRED", { value: t("_Global.email") })),
+      emailRule(t("Error.INVALID_EMAIL")),
+    ]);
+  };
+
+  const passwordValidator = (
+    dirty: ComputedRef<boolean>,
+    password: ComputedRef<string>,
+    t: any, //I18n
+  ) => {
+    return validator(dirty, password, [
+      requiredRule(t("Error.REQUIRED", { value: t("_Global.password") })),
+      minLengthRule(
+        t("Error.MIN_LENGTH", {
+          value: t("_Global.password"),
+          length: DEFAULT_MIN,
+        }),
+      ),
+      maxLengthRule(
+        t("Error.MAX_LENGTH", {
+          value: t("_Global.password"),
+          length: DEFAULT_MAX,
+        }),
+      ),
+    ]);
+  };
+
   return {
     validator,
+    usernameValidator,
+    firstNameValidator,
+    lastNameValidator,
+    emailValidator,
+    passwordValidator,
     passwordRule,
     emailRule,
     maxLengthRule,

--- a/front/langs/en.json
+++ b/front/langs/en.json
@@ -1,6 +1,11 @@
 {
   "_Global": {
-    "update": "Update"
+    "update": "Update",
+    "username": "Username",
+    "firstName": "First name",
+    "lastName": "Last name",
+    "password": "Password",
+    "email": "Email"
   },
   "AuthEmailConfirmed": {
     "description": "You can now enjoy movie!",
@@ -11,25 +16,18 @@
     "login": "Login",
     "noAccount": "<p>You don't have an account yet?</p><p>Click <a class=\"text-primary-500 hover:text-primary-400 underline\" href=\"/en/auth/register\"> here </a> to register</p>",
     "or": "OR",
-    "password": "Password",
-    "title": "Login to get access",
-    "username": "Username"
+    "title": "Login to get access"
   },
   "AuthRegister": {
     "description": "Create an account to enjoy unlimited movies",
-    "email": "Email",
-    "firstName": "First name",
-    "lastName": "Last name",
     "or": "OR",
-    "password": "Password",
     "register": "Register",
     "Stepper": {
       "step1": "Register",
       "step2": "Verify email",
       "step3": "Done"
     },
-    "title": "Welcome to Hypertube!",
-    "username": "Username"
+    "title": "Welcome to Hypertube!"
   },
   "AuthVerifyEmail": {
     "description": "Please check your mail box",
@@ -68,16 +66,11 @@
   },
   "Profile": {
     "Account": {
-      "email": "Email",
       "enterNewPassword": "Enter new password",
-      "password": "Password",
       "title": "Account"
     },
     "Profile": {
-      "firstName": "First name",
-      "lastName": "Last name",
-      "title": "Profile",
-      "username": "Username"
+      "title": "Profile"
     },
     "WatchedList": {
       "title": "Watched list"

--- a/front/langs/fr.json
+++ b/front/langs/fr.json
@@ -1,6 +1,11 @@
 {
   "_Global": {
-    "update": "Mettre à jour"
+    "update": "Mettre à jour",
+    "password": "Mot de passe",
+    "username": "Nom d'utilisateur",
+    "email": "E-mail",
+    "firstName": "Prénom",
+    "lastName": "Nom de famille"
   },
   "AuthEmailConfirmed": {
     "description": "Vous pouvez maintenant profiter du film !",

--- a/front/pages/auth/login.vue
+++ b/front/pages/auth/login.vue
@@ -13,47 +13,11 @@ const { doLogin, onGoogleLogin, onGithubLogin, onFtLogin } = useAuth();
 const { isEmailVerified } = storeToRefs(useUserStore());
 const loading = ref(false);
 const dirty = ref(false);
-const {
-  validator,
-  requiredRule,
-  minLengthRule,
-  maxLengthRule,
-  DEFAULT_MAX,
-  DEFAULT_MIN,
-} = useValidator();
+const { passwordValidator, usernameValidator } = useValidator();
 const { t } = useI18n();
 
-const { error: errorUsername } = validator(dirty, username, [
-  requiredRule(t("Error.REQUIRED", { value: t("AuthLogin.username") })),
-  minLengthRule(
-    t("Error.MIN_LENGTH", {
-      value: t("AuthLogin.username"),
-      length: DEFAULT_MIN,
-    }),
-  ),
-  maxLengthRule(
-    t("Error.MAX_LENGTH", {
-      value: t("AuthLogin.username"),
-      length: DEFAULT_MAX,
-    }),
-  ),
-]);
-
-const { error: errorPassword } = validator(dirty, password, [
-  requiredRule(t("Error.REQUIRED", { value: t("AuthLogin.password") })),
-  minLengthRule(
-    t("Error.MIN_LENGTH", {
-      value: t("AuthLogin.password"),
-      length: DEFAULT_MIN,
-    }),
-  ),
-  maxLengthRule(
-    t("Error.MAX_LENGTH", {
-      value: t("AuthLogin.password"),
-      length: DEFAULT_MAX,
-    }),
-  ),
-]);
+const { error: errorPassword } = passwordValidator(dirty, password, t);
+const { error: errorUsername } = usernameValidator(dirty, username, t);
 const errorGlobal = ref("");
 
 const onLogin = async () => {
@@ -127,7 +91,7 @@ const onLogin = async () => {
           <BaseInput
             v-model="username"
             type="text"
-            :label="$t('AuthLogin.username')"
+            :label="$t('_Global.username')"
             autocomplete="username"
             :error-message="errorUsername"
             :error="!!errorGlobal"
@@ -135,7 +99,7 @@ const onLogin = async () => {
           <BaseInput
             v-model="password"
             type="password"
-            :label="$t('AuthLogin.password')"
+            :label="$t('_Global.password')"
             autocomplete="current-password"
             :error-message="errorPassword"
             :error="!!errorGlobal"

--- a/front/pages/auth/register.vue
+++ b/front/pages/auth/register.vue
@@ -73,32 +73,32 @@ const handleOnSubmit = async () => {
         <BaseInput
           v-model="firstName"
           type="text"
-          :label="$t('AuthRegister.firstName')"
+          :label="$t('_Global.firstName')"
           autocomplete="given-name"
         />
         <BaseInput
           v-model="lastName"
           type="text"
-          :label="$t('AuthRegister.lastName')"
+          :label="$t('_Global.lastName')"
           autocomplete="family-name"
         />
         <BaseInput
           v-model="email"
           type="email"
-          :label="$t('AuthRegister.email')"
+          :label="$t('_Global.email')"
           autocomplete="email"
           class="sm:col-span-2"
         />
         <BaseInput
           v-model="username"
           type="text"
-          :label="$t('AuthRegister.username')"
+          :label="$t('_Global.username')"
           autocomplete="username"
         />
         <BaseInput
           v-model="password"
           type="password"
-          :label="$t('AuthRegister.password')"
+          :label="$t('_Global.password')"
           autocomplete="current-password"
         />
         <Button class="mt-4 w-full sm:col-span-2" type="submit">

--- a/front/pages/auth/register.vue
+++ b/front/pages/auth/register.vue
@@ -16,8 +16,34 @@ const localePath = useLocalePath();
 const { doRegister, onGoogleLogin, onGithubLogin, onFtLogin } = useAuth();
 const { locale } = useI18n();
 
+const {
+  usernameValidator,
+  firstNameValidator,
+  lastNameValidator,
+  emailValidator,
+  passwordValidator,
+} = useValidator();
+const { t } = useI18n();
+const loading = ref(false);
+const dirty = ref(false);
+const { error: errorUsername } = usernameValidator(dirty, username, t);
+const { error: errorFirstName } = firstNameValidator(dirty, firstName, t);
+const { error: errorLastName } = lastNameValidator(dirty, lastName, t);
+const { error: errorEmail } = emailValidator(dirty, email, t);
+const { error: errorPassword } = passwordValidator(dirty, password, t);
+const errorGlobal = ref("");
 // TODO: Validation and show error message
 const handleOnSubmit = async () => {
+  dirty.value = true;
+  if (
+    errorUsername.value ||
+    errorFirstName.value ||
+    errorLastName.value ||
+    errorEmail.value ||
+    errorPassword.value
+  )
+    return;
+
   const userInfo = {
     username: username.value,
     password: password.value,
@@ -27,10 +53,18 @@ const handleOnSubmit = async () => {
   };
 
   try {
+    loading.value = true;
     await doRegister(axios, userInfo, locale.value);
     await navigateTo({ path: localePath("auth-verify-email") });
+    errorGlobal.value = "";
   } catch (e) {
-    console.error(e);
+    if (e.response && e.response.data.code) {
+      errorGlobal.value = t(`Error.${e.response.data.code}`);
+    } else {
+      errorGlobal.value = t(`Error.GENERAL_ERROR`);
+    }
+  } finally {
+    loading.value = false;
   }
 };
 </script>
@@ -75,12 +109,16 @@ const handleOnSubmit = async () => {
           type="text"
           :label="$t('_Global.firstName')"
           autocomplete="given-name"
+          :error-message="errorFirstName"
+          :error="!!errorGlobal"
         />
         <BaseInput
           v-model="lastName"
           type="text"
           :label="$t('_Global.lastName')"
           autocomplete="family-name"
+          :error-message="errorLastName"
+          :error="!!errorGlobal"
         />
         <BaseInput
           v-model="email"
@@ -88,18 +126,24 @@ const handleOnSubmit = async () => {
           :label="$t('_Global.email')"
           autocomplete="email"
           class="sm:col-span-2"
+          :error-message="errorEmail"
+          :error="!!errorGlobal"
         />
         <BaseInput
           v-model="username"
           type="text"
           :label="$t('_Global.username')"
           autocomplete="username"
+          :error-message="errorUsername"
+          :error="!!errorGlobal"
         />
         <BaseInput
           v-model="password"
           type="password"
           :label="$t('_Global.password')"
           autocomplete="current-password"
+          :error-message="errorPassword"
+          :error="!!errorGlobal"
         />
         <Button class="mt-4 w-full sm:col-span-2" type="submit">
           {{ $t("AuthRegister.register") }}

--- a/front/pages/profile.vue
+++ b/front/pages/profile.vue
@@ -12,14 +12,11 @@ definePageMeta({
 //TODO: divide files for each block(Profile, Account, WatchedList)
 const { userData } = storeToRefs(useUserStore());
 const {
-  validator,
-  passwordRule,
-  emailRule,
-  minLengthRule,
-  maxLengthRule,
-  requiredRule,
-  DEFAULT_MAX,
-  DEFAULT_MIN,
+  usernameValidator,
+  emailValidator,
+  firstNameValidator,
+  lastNameValidator,
+  passwordValidator,
 } = useValidator();
 const { t } = useI18n();
 const { updateAvatar, updateProfile } = useProfile();
@@ -51,63 +48,18 @@ const loading = reactive({
   password: false,
 });
 
-const { error: errorUsername } = validator(dirtyProfile, username, [
-  requiredRule(t("Error.REQUIRED", { value: t("Profile.Profile.username") })),
-  minLengthRule(
-    t("Error.MIN_LENGTH", {
-      value: t("Profile.Profile.username"),
-      length: DEFAULT_MIN,
-    }),
-  ),
-  maxLengthRule(
-    t("Error.MAX_LENGTH", {
-      value: t("Profile.Profile.username"),
-      length: DEFAULT_MAX,
-    }),
-  ),
-]);
+const { error: errorUsername } = usernameValidator(dirtyProfile, firstName, t);
 
-const { error: errorFirstName } = validator(dirtyProfile, firstName, [
-  requiredRule(t("Error.REQUIRED", { value: t("Profile.Profile.firstName") })),
-  minLengthRule(
-    t("Error.MIN_LENGTH", {
-      value: t("Profile.Profile.firstName"),
-      length: DEFAULT_MIN,
-    }),
-  ),
-  maxLengthRule(
-    t("Error.MAX_LENGTH", {
-      value: t("Profile.Profile.firstName"),
-      length: DEFAULT_MAX,
-    }),
-  ),
-]);
+const { error: errorFirstName } = firstNameValidator(
+  dirtyProfile,
+  firstName,
+  t,
+);
+const { error: errorLastName } = lastNameValidator(dirtyProfile, lastName, t);
 
-const { error: errorLastName } = validator(dirtyProfile, lastName, [
-  requiredRule(t("Error.REQUIRED", { value: t("Profile.Profile.lastName") })),
-  minLengthRule(
-    t("Error.MIN_LENGTH", {
-      value: t("Profile.Profile.lastName"),
-      length: DEFAULT_MIN,
-    }),
-  ),
-  maxLengthRule(
-    t("Error.MAX_LENGTH", {
-      value: t("Profile.Profile.lastName"),
-      length: DEFAULT_MAX,
-    }),
-  ),
-]);
+const { error: errorEmail } = emailValidator(dirtyEmail, email, t);
 
-const { error: errorEmail } = validator(dirtyEmail, email, [
-  requiredRule(t("Error.REQUIRED", { value: t("Profile.Account.email") })),
-  emailRule(t("Error.INVALID_EMAIL")),
-]);
-
-const { error: errorPassword } = validator(dirtyPassword, password, [
-  requiredRule(t("Error.REQUIRED", { value: t("Profile.Account.password") })),
-  passwordRule(t("Error.INVALID_PASSWORD")),
-]);
+const { error: errorPassword } = passwordValidator(dirtyPassword, password, t);
 
 //TODO: put error handling - will do it after devide component
 async function onUpdateProfile() {
@@ -192,18 +144,18 @@ function onClickAvatar() {
             <BaseInput
               v-model="username"
               :error-message="errorUsername"
-              :label="$t('Profile.Profile.username')"
+              :label="$t('_Global.username')"
               class="md:col-span-2"
             />
             <BaseInput
               v-model="firstName"
               :error-message="errorFirstName"
-              :label="$t('Profile.Profile.firstName')"
+              :label="$t('_Global.firstName')"
             />
             <BaseInput
               v-model="lastName"
               :error-message="errorLastName"
-              :label="$t('Profile.Profile.lastName')"
+              :label="$t('_Global.lastName')"
             />
             <div class="col-span-1 text-right sm:col-span-2">
               <Button
@@ -230,7 +182,7 @@ function onClickAvatar() {
             <BaseInput
               v-model="email"
               :error-message="errorEmail"
-              :label="$t('Profile.Account.email')"
+              :label="$t('_Global.email')"
               autocomplete="none"
               type="email"
               class="w-full"
@@ -246,7 +198,7 @@ function onClickAvatar() {
           <div class="flex flex-col items-start gap-3 sm:flex-row">
             <BaseInput
               v-model="password"
-              :label="$t('Profile.Account.password')"
+              :label="$t('_Global.password')"
               type="password"
               class="w-full"
               :placeholder="$t('Profile.Account.enterNewPassword')"


### PR DESCRIPTION
프로필 / 로그인 / 유저 페이지 모듈들을 살펴봤을때 

username, firstName, lastName, email, password 값들을 global로 이동하고, validator를 페이지별로 불러와 수정하는 방식보다 개별  validator를 생성하여 만드는것이 낫다고 판단하여 리팩토링 진행하였습니다.

기본적인 페이지들은 한번 확인해봤는데 혹시 실수가 있을수 있으니 살펴 봐주시면 감사하겠습니다
마지막 리뷰어분이 approve 눌러주시면 될것 같습니다