### PR TITLE
Profile 페이지 에러 핸들링 / 디자인 수정 등

### DIFF
--- a/back/src/user/user.controller.ts
+++ b/back/src/user/user.controller.ts
@@ -23,7 +23,7 @@ import { cleanImageFile } from 'src/helper';
 @ApiTags('Users')
 @Controller('users')
 export class UserController {
-  constructor(private readonly userService: UserService) {}
+  constructor(private readonly userService: UserService) { }
 
   @ApiOperation({ summary: 'Get all users' })
   @UseGuards(JwtAuthGuard)

--- a/back/src/user/user.service.ts
+++ b/back/src/user/user.service.ts
@@ -97,6 +97,35 @@ export class UserService {
       user.password = await this.cryptPassword(user.password);
     }
 
+    let duplicateUsername;
+    if (user.username) {
+      duplicateUsername = await this.userRepository.findOne({
+        where: [{ username: user.username }],
+      });
+    }
+
+    let duplicateEmail;
+    if (user.email) {
+      duplicateEmail = await this.userRepository.findOne({
+        where: [{ email: user.email }],
+      });
+    }
+
+    if (duplicateEmail && duplicateEmail.email == user.email)
+      throw new UnauthorizedException({ code: 'EMAIL_ALREADY_EXISTS' });
+    else if (duplicateUsername && duplicateUsername.username == user.username)
+      throw new UnauthorizedException({ code: 'USERNAME_ALREADY_EXISTS' });
+
+    // if (duplicateEmail == duplicateUsername && duplicateEmail) {
+    //   if (!duplicateEmail.emailVerified) return duplicateEmail;
+    // } else if (duplicateUsername) {
+    //   if (!duplicateUsername.emailVerified) return duplicateUsername;
+    //   else throw new UnauthorizedException({ code: 'USERNAME_ALREADY_EXISTS' });
+    // } else if (duplicateEmail) {
+    //   if (!duplicateEmail.emailVerified) return duplicateEmail;
+    //   else throw new UnauthorizedException({ code: 'EMAIL_ALREADY_EXISTS' });
+    // }
+
     return this.userRepository.update(id, user);
   }
 

--- a/back/src/user/user.service.ts
+++ b/back/src/user/user.service.ts
@@ -116,16 +116,6 @@ export class UserService {
     else if (duplicateUsername && duplicateUsername.username == user.username)
       throw new UnauthorizedException({ code: 'USERNAME_ALREADY_EXISTS' });
 
-    // if (duplicateEmail == duplicateUsername && duplicateEmail) {
-    //   if (!duplicateEmail.emailVerified) return duplicateEmail;
-    // } else if (duplicateUsername) {
-    //   if (!duplicateUsername.emailVerified) return duplicateUsername;
-    //   else throw new UnauthorizedException({ code: 'USERNAME_ALREADY_EXISTS' });
-    // } else if (duplicateEmail) {
-    //   if (!duplicateEmail.emailVerified) return duplicateEmail;
-    //   else throw new UnauthorizedException({ code: 'EMAIL_ALREADY_EXISTS' });
-    // }
-
     return this.userRepository.update(id, user);
   }
 

--- a/front/components/ProfileSelector.vue
+++ b/front/components/ProfileSelector.vue
@@ -1,5 +1,4 @@
 <script setup>
-import defaultUser from "assets/images/default_user.webp";
 const axios = useAxios();
 const localePath = useLocalePath();
 const auth = useAuth();
@@ -11,7 +10,7 @@ const onLogout = async () => {
     console.error(error);
   }
 };
-const { userData } = storeToRefs(useUserStore());
+const { userImage } = storeToRefs(useUserStore());
 </script>
 
 <template>
@@ -23,7 +22,7 @@ const { userData } = storeToRefs(useUserStore());
       class="flex items-center justify-center"
     >
       <Avatar
-        :image="userData.image.length > 0 ? userData.image : defaultUser"
+        :image="userImage"
         shape="circle"
         class="overflow-hidden"
         size="large"

--- a/front/composables/useProfile.ts
+++ b/front/composables/useProfile.ts
@@ -25,15 +25,7 @@ export const useProfile = () => {
     }
   }
 
-  async function updateProfile(userId: string, userInfo: UserData) {
-    try {
-      await axios.patch("/users/" + userId, userInfo);
-    } catch (e) {
-      console.error(e);
-    }
-  }
-
-  const updateProfileTwo = async (
+  const updateProfile = async (
     api: AxiosInstance,
     userId: string,
     userInfo: UserData,
@@ -42,7 +34,6 @@ export const useProfile = () => {
   };
 
   return {
-    updateProfileTwo,
     updateAvatar,
     updateProfile,
   };

--- a/front/composables/useProfile.ts
+++ b/front/composables/useProfile.ts
@@ -1,3 +1,5 @@
+import type { AxiosInstance } from "axios";
+
 import type { UserData } from "~/types";
 
 export const useProfile = () => {
@@ -26,12 +28,21 @@ export const useProfile = () => {
   async function updateProfile(userId: string, userInfo: UserData) {
     try {
       await axios.patch("/users/" + userId, userInfo);
-      router.go();
     } catch (e) {
       console.error(e);
     }
   }
+
+  const updateProfileTwo = async (
+    api: AxiosInstance,
+    userId: string,
+    userInfo: UserData,
+  ) => {
+    await api.patch("/users/" + userId, userInfo);
+  };
+
   return {
+    updateProfileTwo,
     updateAvatar,
     updateProfile,
   };

--- a/front/langs/en.json
+++ b/front/langs/en.json
@@ -80,7 +80,8 @@
       "title": "Profile"
     },
     "WatchedList": {
-      "title": "Watched list"
+      "title": "Watched list",
+      "noList": "You haven't watched any movie yet."
     }
   }
 }

--- a/front/langs/en.json
+++ b/front/langs/en.json
@@ -1,11 +1,11 @@
 {
   "_Global": {
-    "update": "Update",
-    "username": "Username",
+    "email": "Email",
     "firstName": "First name",
     "lastName": "Last name",
     "password": "Password",
-    "email": "Email"
+    "update": "Update",
+    "username": "Username"
   },
   "AuthEmailConfirmed": {
     "description": "You can now enjoy movie!",
@@ -34,14 +34,15 @@
     "title": "Waiting for your email confirmation"
   },
   "Error": {
+    "EMAIL_ALREADY_EXISTS": "Email already exists.",
     "GENERAL_ERROR": "Unexpected error",
     "INVALID_EMAIL": "Invalid email address",
     "INVALID_LOGIN": "Invalid username or password",
     "INVALID_PASSWORD": "Password must be at least 8 characters long and include an uppercase letter, a lowercase letter, a digit, and a special character.",
     "MAX_LENGTH": "{value} must be less than {length}",
     "MIN_LENGTH": "{value} must be at least {length} characters long.",
+    "PASSWORD_DOES_NOT_MATCH": "Password does not match.",
     "REQUIRED": " {value} is required",
-    "EMAIL_ALREADY_EXISTS": "Email already exists.",
     "USERNAME_ALREADY_EXISTS": "Username already exists."
   },
   "Footer": {
@@ -68,10 +69,14 @@
   },
   "Profile": {
     "Account": {
+      "confirm": "Confirm",
       "enterNewPassword": "Enter new password",
+      "successEmail": "Email update successful.",
+      "successPassword": "Password update successful.",
       "title": "Account"
     },
     "Profile": {
+      "success": "User profile update successful.",
       "title": "Profile"
     },
     "WatchedList": {

--- a/front/langs/fr.json
+++ b/front/langs/fr.json
@@ -81,7 +81,8 @@
       "title": "Profil"
     },
     "WatchedList": {
-      "title": "Liste déjà vu"
+      "title": "Liste déjà vu",
+      "noList": "Vous n'avez jamais vu aucun film."
     }
   }
 }

--- a/front/langs/fr.json
+++ b/front/langs/fr.json
@@ -1,11 +1,11 @@
 {
   "_Global": {
-    "update": "Mettre à jour",
-    "password": "Mot de passe",
-    "username": "Nom d'utilisateur",
     "email": "E-mail",
     "firstName": "Prénom",
-    "lastName": "Nom de famille"
+    "lastName": "Nom de famille",
+    "password": "Mot de passe",
+    "update": "Mettre à jour",
+    "username": "Nom d'utilisateur"
   },
   "AuthEmailConfirmed": {
     "description": "Vous pouvez maintenant profiter du film !",
@@ -34,14 +34,15 @@
     "title": "En attente de votre email de confirmation"
   },
   "Error": {
+    "EMAIL_ALREADY_EXISTS": "L'adresse e-mail existe déjà.",
     "GENERAL_ERROR": "Erreur inattendue",
     "INVALID_EMAIL": "Adresse email invalide",
     "INVALID_LOGIN": "Nom d'utilisateur ou mot de passe invalide",
     "INVALID_PASSWORD": "Le mot de passe doit avoir au moins 8 caractères et contenir une lettre majuscule, une lettre minuscule, un chiffre et un caractère spécial.",
     "MAX_LENGTH": "{value} doit comporter mois de {length} caractères",
     "MIN_LENGTH": "{value} doit comporter au moins {length} caractères.",
+    "PASSWORD_DOES_NOT_MATCH": "Le mot de passe ne correspond pas.",
     "REQUIRED": "{value} est obligatoire",
-    "EMAIL_ALREADY_EXISTS": "L'adresse e-mail existe déjà.",
     "USERNAME_ALREADY_EXISTS": "Le nom d'utilisateur existe déjà."
   },
   "Footer": {
@@ -68,10 +69,15 @@
   },
   "Profile": {
     "Account": {
+      "confirm": "Confirmer",
       "enterNewPassword": "Mettre le nouveau mot de passe",
+      "success": "Mise à jour du compte utilisateur réussie.",
+      "successEmail": "Mise à jour par e-mail réussie.",
+      "successPassword": "Mise à jour du mot de passe réussie.",
       "title": "Compte"
     },
     "Profile": {
+      "success": "Mise à jour du profil utilisateur réussie.",
       "title": "Profil"
     },
     "WatchedList": {

--- a/front/layouts/profile.vue
+++ b/front/layouts/profile.vue
@@ -1,7 +1,7 @@
 <template>
   <TheNavbar />
   <main
-    class="flex min-h-[calc(100vh-64px)] flex-col items-center justify-center bg-slate-900 px-4 pb-32 pt-[112px] lg:p-8 lg:pt-[112px]"
+    class="flex min-h-[calc(100vh-64px)] flex-col items-center justify-center px-4 pb-32 pt-[112px] lg:p-8 lg:pt-[112px]"
   >
     <slot />
   </main>

--- a/front/layouts/profile.vue
+++ b/front/layouts/profile.vue
@@ -1,0 +1,9 @@
+<template>
+  <TheNavbar />
+  <main
+    class="flex min-h-[calc(100vh-64px)] flex-col items-center justify-center bg-slate-900 px-4 pb-32 pt-[112px] lg:p-8 lg:pt-[112px]"
+  >
+    <slot />
+  </main>
+  <TheFooter />
+</template>

--- a/front/pages/profile.vue
+++ b/front/pages/profile.vue
@@ -3,8 +3,6 @@ import "swiper/css";
 import "swiper/css/free-mode";
 import "swiper/css/pagination";
 
-import defaultUser from "assets/images/default_user.webp";
-
 import { useProfile } from "../composables/useProfile";
 
 definePageMeta({
@@ -13,7 +11,7 @@ definePageMeta({
 });
 
 //TODO: divide files for each block(Profile, Account, WatchedList)
-const { userData } = storeToRefs(useUserStore());
+const { userData, userImage } = storeToRefs(useUserStore());
 const {
   usernameValidator,
   emailValidator,
@@ -31,14 +29,6 @@ const firstName = ref(userData.value?.firstName);
 const lastName = ref(userData.value?.lastName);
 const password = ref("");
 const confirmPassword = ref("");
-const avatar = computed({
-  get() {
-    return userData.value?.image;
-  },
-  set(image) {
-    userData.value.image = image;
-  },
-});
 const fileInput = ref(null);
 
 const isProfileUpdateButtonDisabled = () => {
@@ -49,9 +39,9 @@ const isProfileUpdateButtonDisabled = () => {
   );
 };
 
-const isEmailUpdateButtonDisabled = () => {
-  return userData.value?.email === email.value;
-};
+const isEmailUpdateButtonDisabled = computed(
+  () => userData.value?.email === email.value,
+);
 
 /* dirtys */
 const dirtyProfile = ref(false);
@@ -191,20 +181,16 @@ function onClickAvatar() {
 }
 </script>
 <template>
-  <main class="flex min-h-[calc(100vh-64px)] px-4 pb-20 pt-10 md:px-8">
-    <div class="mx-auto flex max-w-[540px] flex-col flex-wrap gap-10">
-      <section>
+  <main class="min-h-[calc(100vh-64px)] pb-20 pt-10">
+    <div class="mx-auto grid grid-cols-1 gap-10 md:grid-cols-2">
+      <section class="w-[90vw] sm:w-auto">
         <h2 class="mb-4 text-3xl font-bold text-primary-400">
           {{ $t("Profile.Profile.title") }}
         </h2>
-        <div class="bg-slate-800">
-          <div class="relative flex items-center justify-center">
-            <Avatar
-              :image="avatar.length > 0 ? avatar : defaultUser"
-              size="xlarge"
-              shape="circle"
-              class="m-auto overflow-hidden"
-            />
+
+        <div class="rounded-lg bg-slate-800 p-4 md:p-8">
+          <div class="relative mb-5 flex items-center justify-center">
+            <img :src="userImage" class="h-[150px] w-[150px] rounded-[50%]" />
             <i
               class="pi pi-images absolute m-auto cursor-pointer p-20 opacity-0 transition-opacity duration-300 hover:opacity-100"
               style="font-size: 2rem"
@@ -219,12 +205,14 @@ function onClickAvatar() {
               @change="updateAvatar"
             />
           </div>
-          <br />
+
           <div
-            class="mx-auto flex flex-col items-center justify-center gap-5 rounded-lg p-5 sm:flex-row"
+            class="mx-auto flex flex-col items-center justify-center gap-5 rounded-lg sm:flex-row"
           >
-            <form @submit.prevent="onUpdateProfile">
-              <aside class="grid flex-1 grid-cols-1 gap-6 md:grid-cols-2">
+            <form class="w-full" @submit.prevent="onUpdateProfile">
+              <aside
+                class="grid w-full grid-cols-1 gap-6 sm:w-auto sm:grid-cols-2"
+              >
                 <BaseInput
                   v-model="username"
                   type="text"
@@ -232,7 +220,7 @@ function onClickAvatar() {
                   autocomplete="username"
                   :error-message="errorUsername"
                   :error="!!errorUpdateProfile"
-                  class="md:col-span-2"
+                  class="col-span-1 sm:col-span-2"
                 />
                 <BaseInput
                   v-model="firstName"
@@ -250,18 +238,22 @@ function onClickAvatar() {
                   :error-message="errorLastName"
                   :error="!!errorUpdateProfile"
                 />
-                <small
-                  v-if="dirtyProfile && errorUpdateProfile"
-                  class="mt-2 text-lg text-red-500"
-                >
-                  {{ errorUpdateProfile }}
-                </small>
-                <small
-                  v-if="userProfileUpdateSuccessful"
-                  class="mt-2 text-lg text-blue-500"
-                >
-                  {{ userProfileUpdateSuccessful }}
-                </small>
+
+                <div class="col-span-1 sm:col-span-2">
+                  <small
+                    v-if="dirtyProfile && errorUpdateProfile"
+                    class="mt-2 text-lg text-red-500"
+                  >
+                    {{ errorUpdateProfile }}
+                  </small>
+                  <small
+                    v-if="userProfileUpdateSuccessful"
+                    class="mt-2 text-lg text-blue-500"
+                  >
+                    {{ userProfileUpdateSuccessful }}
+                  </small>
+                </div>
+
                 <div class="col-span-1 text-right sm:col-span-2">
                   <Button
                     v-once
@@ -272,7 +264,7 @@ function onClickAvatar() {
                         ? null
                         : `${$t('_Global.update')} ${t('Profile.Profile.title')}`
                     "
-                    class="w-full min-w-32 sm:w-fit"
+                    class="w-full sm:w-fit"
                     @click="
                       isProfileUpdateButtonDisabled ? null : onUpdateProfile
                     "
@@ -284,12 +276,14 @@ function onClickAvatar() {
         </div>
       </section>
 
-      <section>
-        <h2 class="mb-4 text-3xl font-bold text-primary-400">
+      <section class="flex w-full flex-col">
+        <h2 class="mb-4 w-full text-3xl font-bold text-primary-400">
           {{ $t("Profile.Account.title") }}
         </h2>
-        <div class="mx-auto flex flex-col gap-3 rounded-lg bg-slate-800 p-4">
-          <form class="pb-2" @submit.prevent="onUpdateEmail">
+        <div
+          class="flex flex-1 flex-col justify-between gap-8 rounded-lg bg-slate-800 p-4 md:p-8"
+        >
+          <form class="flex flex-col gap-4" @submit.prevent="onUpdateEmail">
             <!-- First Row -->
             <BaseInput
               v-model="email"
@@ -297,11 +291,11 @@ function onClickAvatar() {
               :label="$t('_Global.email')"
               autocomplete="none"
               type="email"
-              class="w-full p-2"
+              class="w-full"
             />
 
             <!-- Second Row -->
-            <div class="mt-2 flex items-center justify-between p-2">
+            <div>
               <div class="text-left">
                 <small
                   v-if="dirtyEmail && errorUpdateEmail"
@@ -316,17 +310,21 @@ function onClickAvatar() {
                   {{ userEmailUpdateSuccessful }}
                 </small>
               </div>
-              <Button
-                type="submit"
-                class="min-w-32 whitespace-nowrap"
-                :loading="loading.email"
-                :label="loading.email ? null : $t('_Global.update')"
-                @click="isEmailUpdateButtonDisabled ? null : onUpdateProfile"
-              />
+
+              <div class="text-right">
+                <Button
+                  type="submit"
+                  class="w-full sm:w-auto"
+                  :loading="loading.email"
+                  :label="loading.email ? null : $t('_Global.update')"
+                  :disabled="isEmailUpdateButtonDisabled"
+                  @click="onUpdateProfile"
+                />
+              </div>
             </div>
           </form>
 
-          <form class="pb-2" @submit.prevent="onUpdatePassword">
+          <form class="grid gap-2" @submit.prevent="onUpdatePassword">
             <!-- First Row -->
             <BaseInput
               v-model="password"
@@ -334,7 +332,7 @@ function onClickAvatar() {
               :label="$t('_Global.password')"
               autocomplete="none"
               type="password"
-              class="w-full p-2"
+              class="w-full"
             />
 
             <BaseInput
@@ -345,30 +343,29 @@ function onClickAvatar() {
               "
               autocomplete="none"
               type="password"
-              class="w-full p-2"
+              class="w-full"
             />
 
             <!-- Second Row -->
-            <div
-              class="mt-2 flex items-center justify-between bg-slate-800 p-2"
-            >
-              <div class="text-left">
-                <small
-                  v-if="dirtyPassword && errorUpdatePassword"
-                  class="mt-2 text-lg text-red-500"
-                >
-                  {{ errorUpdatePassword }}
-                </small>
-                <small
-                  v-if="userPasswordUpdateSuccessful"
-                  class="mt-2 text-lg text-blue-500"
-                >
-                  {{ userPasswordUpdateSuccessful }}
-                </small>
-              </div>
+            <div>
+              <small
+                v-if="dirtyPassword && errorUpdatePassword"
+                class="mt-2 text-red-500"
+              >
+                {{ errorUpdatePassword }}
+              </small>
+              <small
+                v-if="userPasswordUpdateSuccessful"
+                class="mt-2 text-blue-500"
+              >
+                {{ userPasswordUpdateSuccessful }}
+              </small>
+            </div>
+
+            <div class="text-right">
               <Button
                 type="submit"
-                class="min-w-32 whitespace-nowrap"
+                class="w-full sm:w-auto"
                 :loading="loading.password"
                 :label="loading.passoword ? null : $t('_Global.update')"
               />
@@ -377,10 +374,16 @@ function onClickAvatar() {
         </div>
       </section>
 
-      <section>
+      <section class="col-span-1 md:col-span-2">
         <h2 class="mb-4 text-3xl font-bold text-primary-400">
           {{ $t("Profile.WatchedList.title") }}
         </h2>
+
+        <div class="h-full min-h-[250px] rounded-lg bg-slate-800 p-4 md:p-8">
+          <p class="text-xl text-white">
+            {{ $t("Profile.WatchedList.noList") }}
+          </p>
+        </div>
       </section>
     </div>
   </main>

--- a/front/pages/profile.vue
+++ b/front/pages/profile.vue
@@ -197,7 +197,7 @@ function onClickAvatar() {
         <h2 class="mb-4 text-3xl font-bold text-primary-400">
           {{ $t("Profile.Profile.title") }}
         </h2>
-        <div class="bg-surface-900">
+        <div class="bg-slate-800">
           <div class="relative flex items-center justify-center">
             <Avatar
               :image="avatar.length > 0 ? avatar : defaultUser"
@@ -221,7 +221,7 @@ function onClickAvatar() {
           </div>
           <br />
           <div
-            class="mx-auto flex flex-col items-center justify-center gap-5 rounded-lg p-4 sm:flex-row"
+            class="mx-auto flex flex-col items-center justify-center gap-5 rounded-lg p-5 sm:flex-row"
           >
             <form @submit.prevent="onUpdateProfile">
               <aside class="grid flex-1 grid-cols-1 gap-6 md:grid-cols-2">
@@ -288,7 +288,7 @@ function onClickAvatar() {
         <h2 class="mb-4 text-3xl font-bold text-primary-400">
           {{ $t("Profile.Account.title") }}
         </h2>
-        <div class="mx-auto flex flex-col gap-3 rounded-lg bg-surface-900 p-4">
+        <div class="mx-auto flex flex-col gap-3 rounded-lg bg-slate-800 p-4">
           <form class="pb-2" @submit.prevent="onUpdateEmail">
             <!-- First Row -->
             <BaseInput
@@ -347,7 +347,9 @@ function onClickAvatar() {
             />
 
             <!-- Second Row -->
-            <div class="mt-2 flex items-center justify-between p-2">
+            <div
+              class="mt-2 flex items-center justify-between bg-slate-800 p-2"
+            >
               <div class="text-left">
                 <small
                   v-if="dirtyPassword && errorUpdatePassword"

--- a/front/pages/profile.vue
+++ b/front/pages/profile.vue
@@ -99,7 +99,7 @@ const onUpdateProfile = async () => {
     errorUpdateProfile.value = "";
     userProfileUpdateSuccessful.value = "User profile update successful";
   } catch (e) {
-    console.log(e);
+    userProfileUpdateSuccessful.value = "";
     if (e.response && e.response.data.code) {
       errorUpdateProfile.value = t(`Error.${e.response.data.code}`);
     } else {

--- a/front/pages/profile.vue
+++ b/front/pages/profile.vue
@@ -112,7 +112,7 @@ const onUpdateProfile = async () => {
     });
     // TODO: instead of printing error
     errorUpdateProfile.value = "";
-    userProfileUpdateSuccessful.value = "User profile update successful";
+    userProfileUpdateSuccessful.value = t("Profile.Profile.success");
   } catch (e) {
     userProfileUpdateSuccessful.value = "";
     if (e.response && e.response.data.code) {
@@ -141,7 +141,7 @@ async function onUpdateEmail() {
       email: email.value,
     });
     errorUpdateEmail.value = "";
-    userEmailUpdateSuccessful.value = "User Email update successful";
+    userEmailUpdateSuccessful.value = t("Profile.Account.successEmail");
   } catch (e) {
     userEmailUpdateSuccessful.value = "";
     if (e.response && e.response.data.code) {
@@ -161,7 +161,7 @@ async function onUpdatePassword() {
   if (!password.value || !confirmPassword.value) return;
 
   if (password.value != confirmPassword.value) {
-    errorUpdatePassword.value = "Password does not match";
+    errorUpdatePassword.value = t("Error.PASSWORD_DOES_NOT_MATCH");
     return;
   }
 
@@ -173,7 +173,7 @@ async function onUpdatePassword() {
       password: password.value,
     });
     errorUpdatePassword.value = "";
-    userPasswordUpdateSuccessful.value = "User Password update successful";
+    userPasswordUpdateSuccessful.value = t("Profile.Account.successPassword");
   } catch (e) {
     userPasswordUpdateSuccessful.value = "";
     if (e.response && e.response.data.code) {
@@ -340,7 +340,9 @@ function onClickAvatar() {
             <BaseInput
               v-model="confirmPassword"
               :error-message="errorConfirmPassword"
-              :label="'Confirm ' + $t('_Global.password')"
+              :label="
+                t('Profile.Account.confirm') + ' ' + $t('_Global.password')
+              "
               autocomplete="none"
               type="password"
               class="w-full p-2"

--- a/front/stores/user.store.ts
+++ b/front/stores/user.store.ts
@@ -1,3 +1,4 @@
+import defaultAvatar from "~/assets/images/default_user.webp";
 import type { UserData } from "~/types";
 
 export const useUserStore = defineStore("user", () => {
@@ -6,11 +7,15 @@ export const useUserStore = defineStore("user", () => {
 
   const isLoggedIn = computed(() => !!userData.value.accessToken);
   const isEmailVerified = computed(() => userData.value.emailVerified);
+  const userImage = computed(() => {
+    return userData.value?.image ?? defaultAvatar;
+  });
 
   return {
     isLoggedIn,
     isEmailVerified,
     userData,
     refreshTokenIntervalId,
+    userImage,
   };
 });

--- a/front/types/index.ts
+++ b/front/types/index.ts
@@ -6,6 +6,7 @@ export interface UserData {
   email?: string;
   emailVerified?: boolean;
   accessToken?: string;
+  image?: string;
 }
 
 export interface MovieData {


### PR DESCRIPTION
issue #39 에서 언급된 사항들:
- 프로파일 이미지 올리가(게)
- 제목과 컨테이너 간격 넓히기
- 컨테이너 배경색 조금 밝게 (또는 다른 색으로 ex) bg-slate-800)
- 컨테이너 패딩 넓히기

중에서 슬랙으로 이야기 나눈대로 프로필 이미지 부분 사이즈 수정을 제외하고 작업하였고,

각 입력 폼 (profile, account;email, account;password)에서 프론트엔드 validation 동작을 확인하였습니다.
임의로 confirm password 폼과 로직도 처리 하였으니 확인 부탁드립니다.


백엔드 쪽에서 email, password 가 존재 하지 않을 경우 '유저네임 이미 존재', '이메일 이미 존재' 의 에러처리도 진행 하였습니다.

**모든 폼 버튼클릭이 하나의 엔드포인트를 사용하고 있으니 유의해주세요.**

안된것 & 살펴 보아야 할것:

- 각 BaseButton 컴포넌트에서 버튼 disable의 경우 property(? 라고 하나요) 에서 `:disable`을 활용하여 버튼 클릭 금지를 시도 하였으나 현재는 @clicked=를 활용하여 우선 동작은 안하도록 처리 하였습니다. 
- 각 스크린별 레이아웃 작업이 하나도 되어있지 않습니다.
- 이메일 변경시 verify 관련 처리가 현재 없긴 합니다. 이메일이 변경 되었을때 필요할것 같긴 한데, 사실 저는 없어도 상관없다 쪽이긴 하지만... 의견 나눠볼 필요는 있을것 같습니다.

close: #39 