### PR TITLE
Forgot password & 이메일 발송기능 구현

### DIFF
--- a/back/src/auth/auth.controller.ts
+++ b/back/src/auth/auth.controller.ts
@@ -32,7 +32,7 @@ export class AuthController {
     private userService: UserService,
     private emailService: EmailService,
     private jwtService: JwtService,
-  ) { }
+  ) {}
 
   @UseGuards(LocalAuthGuard)
   @Post('/login')
@@ -171,7 +171,6 @@ export class AuthController {
     @Query('lang') lang,
     @Body() userInfo: ForgotPasswordDto,
   ) {
-    // console.log(userInfo);
     try {
       const foundEmail = await this.userService.findOneByEmail(userInfo.email);
       const foundUsername = await this.userService.findOneByUsername(
@@ -180,7 +179,6 @@ export class AuthController {
       if (!foundEmail || !foundUsername) {
         throw new BadRequestException({ code: 'INVALID_USER_CREDENTIALS' });
       } else if (!(foundEmail.id === foundUsername.id)) {
-        console.log('hi there');
         throw new BadRequestException({ code: 'INVALID_USER_CREDENTIALS' });
       }
 
@@ -205,11 +203,9 @@ export class AuthController {
       secret: process.env.JWT_SECRET,
     });
     const user = await this.userService.findOneById(payload.userId);
-    console.log(user);
     //TODO: save tokens into DB
     // await this.userService.update(user.id, { ...user, emailVerified: true });
 
-    console.log('hi');
     const userId = payload.userId;
     const { accessToken, ...accessOption } =
       this.authService.getCookieWithJwtAccessToken(userId);
@@ -228,7 +224,7 @@ export class AuthController {
 
   @Get('google/login')
   @UseGuards(GoogleAuthGuard)
-  async googleLogin() { }
+  async googleLogin() {}
 
   @Get('google/redirect')
   @UseGuards(GoogleAuthGuard)
@@ -239,7 +235,7 @@ export class AuthController {
 
   @Get('ft/login')
   @UseGuards(FtAuthGuard)
-  async ftLogin() { }
+  async ftLogin() {}
 
   @Get('ft/redirect')
   @UseGuards(FtAuthGuard)
@@ -250,7 +246,7 @@ export class AuthController {
 
   @Get('github/login')
   @UseGuards(GithubAuthGuard)
-  async githubLogin() { }
+  async githubLogin() {}
 
   @Get('github/redirect')
   @UseGuards(GithubAuthGuard)

--- a/back/src/auth/auth.controller.ts
+++ b/back/src/auth/auth.controller.ts
@@ -10,6 +10,8 @@ import {
   Query,
   BadRequestException,
   Logger,
+  UsePipes,
+  NotFoundException,
 } from '@nestjs/common';
 import { LocalAuthGuard } from 'src/guards/local-auth.guard';
 import { AuthService } from './auth.service';
@@ -21,6 +23,7 @@ import { FtAuthGuard } from 'src/guards/ft-auth.guard';
 import { GithubAuthGuard } from 'src/guards/github-auth.guard';
 import { EmailService } from './email.service';
 import { JwtService } from '@nestjs/jwt';
+import { ForgotPasswordDto } from './dto/forgot-password.dto';
 
 @Controller('auth')
 export class AuthController {
@@ -161,6 +164,25 @@ export class AuthController {
     await this.userService.update(user.id, { ...user, emailVerified: true });
 
     res.redirect(`${process.env.FRONT_HOST}/${lang}/auth/email-confirmed`);
+  }
+
+  @Post('/forgot-password')
+  async forgotPasswordFindUser(@Body() userInfo: ForgotPasswordDto) {
+    console.log(userInfo);
+    try {
+      const foundEmail = await this.userService.findOneByEmail(userInfo.email);
+      const foundUsername = await this.userService.findOneByEmail(
+        userInfo.username,
+      );
+
+      if (!foundEmail || !foundUsername || foundEmail !== foundUsername) {
+        throw new BadRequestException({ code: 'INVALID_USER_CREDENTIAL' });
+      }
+
+      return foundEmail;
+    } catch (error) {
+      throw error;
+    }
   }
 
   @Get('google/login')

--- a/back/src/auth/auth.controller.ts
+++ b/back/src/auth/auth.controller.ts
@@ -205,8 +205,11 @@ export class AuthController {
       secret: process.env.JWT_SECRET,
     });
     const user = await this.userService.findOneById(payload.userId);
-    await this.userService.update(user.id, { ...user, emailVerified: true });
+    console.log(user);
+    //TODO: save tokens into DB
+    // await this.userService.update(user.id, { ...user, emailVerified: true });
 
+    console.log('hi');
     const userId = payload.userId;
     const { accessToken, ...accessOption } =
       this.authService.getCookieWithJwtAccessToken(userId);

--- a/back/src/auth/auth.controller.ts
+++ b/back/src/auth/auth.controller.ts
@@ -167,18 +167,28 @@ export class AuthController {
   }
 
   @Post('/forgot-password')
-  async forgotPasswordFindUser(@Body() userInfo: ForgotPasswordDto) {
-    console.log(userInfo);
+  async forgotPasswordFindUser(
+    @Query('lang') lang,
+    @Body() userInfo: ForgotPasswordDto,
+  ) {
+    // console.log(userInfo);
     try {
       const foundEmail = await this.userService.findOneByEmail(userInfo.email);
-      const foundUsername = await this.userService.findOneByEmail(
+      const foundUsername = await this.userService.findOneByUsername(
         userInfo.username,
       );
-
-      if (!foundEmail || !foundUsername || foundEmail !== foundUsername) {
-        throw new BadRequestException({ code: 'INVALID_USER_CREDENTIAL' });
+      if (!foundEmail || !foundUsername) {
+        throw new BadRequestException({ code: 'INVALID_USER_CREDENTIALS' });
+      } else if (!(foundEmail.id === foundUsername.id)) {
+        console.log('hi there');
+        throw new BadRequestException({ code: 'INVALID_USER_CREDENTIALS' });
       }
 
+      // Send email confirmation email
+      await this.emailService.sendPasswordResetEmail(
+        { id: foundEmail.id, email: foundEmail.email },
+        lang || 'en',
+      );
       return foundEmail;
     } catch (error) {
       throw error;

--- a/back/src/auth/dto/forgot-password.dto.ts
+++ b/back/src/auth/dto/forgot-password.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty, PickType } from '@nestjs/swagger';
+import { IsEmail, IsNotEmpty, IsString } from 'class-validator';
+import { User } from 'src/user/user.entity';
+
+export class ForgotPasswordDto extends PickType(User, [
+  'username',
+  'email',
+] as const) {
+  @ApiProperty({
+    description: 'username of user',
+    example: 'marvin',
+  })
+  @IsString()
+  @IsNotEmpty()
+  username: string;
+
+  @ApiProperty({
+    description: 'email of user',
+    example: 'marvin@student.42.fr',
+  })
+  @IsEmail()
+  @IsNotEmpty()
+  email: string;
+}

--- a/back/src/auth/email.service.ts
+++ b/back/src/auth/email.service.ts
@@ -73,11 +73,11 @@ export class EmailService {
     const template = {
       en: {
         subject: 'Password reset for Hypertube',
-        html: `<a href="${process.env.BACK_HOST}/auth/verify-email?token=${token}&lang=${lang}">Password reset for Hypertube</a>`,
+        html: `<a href="${process.env.BACK_HOST}/auth/reset-password?token=${token}&lang=${lang}">Password reset for Hypertube</a>`,
       },
       fr: {
         subject: 'Réinitialisation du mot de passe pour Hypertube',
-        html: `<a href="${process.env.BACK_HOST}/auth/verify-email?token=${token}&lang=${lang}"Réinitialisation du mot de passe pour Hypertube</a>`,
+        html: `<a href="${process.env.BACK_HOST}/auth/reset-password?token=${token}&lang=${lang}"Réinitialisation du mot de passe pour Hypertube</a>`,
       },
     };
     const mailOptions = {

--- a/back/src/auth/email.service.ts
+++ b/back/src/auth/email.service.ts
@@ -77,7 +77,7 @@ export class EmailService {
       },
       fr: {
         subject: 'Réinitialisation du mot de passe pour Hypertube',
-        html: `<a href="${process.env.BACK_HOST}/auth/reset-password?token=${token}&lang=${lang}"Réinitialisation du mot de passe pour Hypertube</a>`,
+        html: `<a href="${process.env.BACK_HOST}/auth/reset-password?token=${token}&lang=${lang}">Réinitialisation du mot de passe pour Hypertube</a>`,
       },
     };
     const mailOptions = {

--- a/back/src/auth/email.service.ts
+++ b/back/src/auth/email.service.ts
@@ -58,4 +58,43 @@ export class EmailService {
       throw new ServiceUnavailableException("Can't send email");
     }
   }
+
+  async sendPasswordResetEmail(
+    data: { id: string; email: string },
+    lang: 'en' | 'fr',
+  ) {
+    const token = this.jwtService.sign(
+      { userId: data.id },
+      {
+        secret: process.env.JWT_SECRET,
+        expiresIn: `${24 * 60 * 60}s`, // 24 hours
+      },
+    );
+    const template = {
+      en: {
+        subject: 'Password reset for Hypertube',
+        html: `<a href="${process.env.BACK_HOST}/auth/verify-email?token=${token}&lang=${lang}">Password reset for Hypertube</a>`,
+      },
+      fr: {
+        subject: 'Réinitialisation du mot de passe pour Hypertube',
+        html: `<a href="${process.env.BACK_HOST}/auth/verify-email?token=${token}&lang=${lang}"Réinitialisation du mot de passe pour Hypertube</a>`,
+      },
+    };
+    const mailOptions = {
+      from: {
+        name: 'Hypertube',
+        address: process.env.GMAIL_ID,
+      },
+      to: data.email,
+      subject: template[lang].subject,
+      html: template[lang].html,
+    };
+    try {
+      await this.transporter.sendMail(mailOptions);
+      Logger.log('Password reset email sent to ' + data.email);
+      Logger.log(template[lang].html);
+    } catch (error) {
+      throw new ServiceUnavailableException("Can't send password reset email");
+    }
+  }
 }

--- a/back/src/user/user.controller.ts
+++ b/back/src/user/user.controller.ts
@@ -9,6 +9,10 @@ import {
   UseInterceptors,
   UseGuards,
   UploadedFile,
+  Query,
+  ValidationPipe,
+  UsePipes,
+  BadRequestException,
 } from '@nestjs/common';
 import { UserService } from './user.service';
 import { User } from './user.entity';

--- a/back/src/user/user.service.ts
+++ b/back/src/user/user.service.ts
@@ -3,7 +3,6 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Connection, Repository } from 'typeorm';
 import { User } from './user.entity';
 import bcrypt from 'bcrypt';
-
 import { CreateUserDto } from '../auth/dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { UpdateResult } from 'typeorm';

--- a/front/components/PageMovie/LeaveComment.vue
+++ b/front/components/PageMovie/LeaveComment.vue
@@ -1,12 +1,12 @@
 <script setup>
 const comment = ref();
-const { userData } = storeToRefs(useUserStore());
+const { userImage } = storeToRefs(useUserStore());
 </script>
 
 <template>
   <form class="flex gap-4" @submit.prevent="() => {}">
     <Avatar
-      :image="userData.image"
+      :image="userImage"
       class="shrink-0 overflow-hidden"
       size="large"
       shape="circle"

--- a/front/composables/useAuth.ts
+++ b/front/composables/useAuth.ts
@@ -70,6 +70,17 @@ export const useAuth = () => {
     stopRefreshAuth();
   };
 
+  const doCheckUserCredentials = async (
+    api: AxiosInstance,
+    info: { email: string },
+  ) => {
+    const { data } = await api.get("/users/check-user", {
+      email: info.email,
+    });
+    userData.value = data;
+    startRefreshAuth();
+  };
+
   const doRegister = async (
     api: AxiosInstance,
     info: UserData,
@@ -95,6 +106,7 @@ export const useAuth = () => {
     doLogin,
     doLogout,
     doRegister,
+    doCheckUserCredentials,
     onGoogleLogin,
     onFtLogin,
     onGithubLogin,

--- a/front/composables/useAuth.ts
+++ b/front/composables/useAuth.ts
@@ -76,8 +76,6 @@ export const useAuth = () => {
     lang: string,
   ) => {
     await api.post(`/auth/forgot-password?lang=${lang}`, info);
-    // userData.value = data;
-    // startRefreshAuth();
   };
 
   const doRegister = async (

--- a/front/composables/useAuth.ts
+++ b/front/composables/useAuth.ts
@@ -72,13 +72,12 @@ export const useAuth = () => {
 
   const doCheckUserCredentials = async (
     api: AxiosInstance,
-    info: { email: string },
+    info: { username: string; email: string },
+    lang: string,
   ) => {
-    const { data } = await api.get("/users/check-user", {
-      email: info.email,
-    });
-    userData.value = data;
-    startRefreshAuth();
+    await api.post(`/auth/forgot-password?lang=${lang}`, info);
+    // userData.value = data;
+    // startRefreshAuth();
   };
 
   const doRegister = async (

--- a/front/composables/useValidator.ts
+++ b/front/composables/useValidator.ts
@@ -70,16 +70,10 @@ export const useValidator = () => {
     dirty: ComputedRef<boolean>,
     firstName: ComputedRef<string>,
     t: any, //I18n
-<<<<<<< HEAD
+
   ) => {
     return validator(dirty, firstName, [
       requiredRule(t("Error.REQUIRED", { value: t("_Global.firstName") })),
-=======
-    pageModule: any,
-  ) => {
-    return validator(dirty, firstName, [
-      requiredRule(t("Error.REQUIRED", { value: pageModule })),
->>>>>>> bed6999 (refactor: generate globally used validators for profile and account info)
       minLengthRule(
         t("Error.MIN_LENGTH", {
           value: t("_Global.firstName"),
@@ -97,11 +91,10 @@ export const useValidator = () => {
 
   const lastNameValidator = (
     dirty: ComputedRef<boolean>,
-    lastName: ComputedRef<string>,
+    password: ComputedRef<string>,
     t: any, //I18n
   ) => {
-    return validator(dirty, lastName, [
-<<<<<<< HEAD
+    return validator(dirty, password, [
       requiredRule(t("Error.REQUIRED", { value: t("_Global.lastName") })),
       minLengthRule(
         t("Error.MIN_LENGTH", {
@@ -118,12 +111,6 @@ export const useValidator = () => {
     ]);
   };
 
-=======
-      requiredRule(t("Error.REQUIRED", { value: t("_Global.password") })),
-      passwordRule(t("Error.INVALID_PASSWORD")),
-    ]);
-  };
->>>>>>> bed6999 (refactor: generate globally used validators for profile and account info)
   const emailValidator = (
     dirty: ComputedRef<boolean>,
     email: ComputedRef<string>,
@@ -137,27 +124,12 @@ export const useValidator = () => {
 
   const passwordValidator = (
     dirty: ComputedRef<boolean>,
-    password: ComputedRef<string>,
+    lastName: ComputedRef<string>,
     t: any, //I18n
   ) => {
-    return validator(dirty, password, [
+    return validator(dirty, lastName, [
       requiredRule(t("Error.REQUIRED", { value: t("_Global.password") })),
-<<<<<<< HEAD
       passwordRule(t("Error.INVALID_PASSWORD")),
-=======
-      minLengthRule(
-        t("Error.MIN_LENGTH", {
-          value: t("_Global.password"),
-          length: DEFAULT_MIN,
-        }),
-      ),
-      maxLengthRule(
-        t("Error.MAX_LENGTH", {
-          value: t("_Global.password"),
-          length: DEFAULT_MAX,
-        }),
-      ),
->>>>>>> bed6999 (refactor: generate globally used validators for profile and account info)
     ]);
   };
 

--- a/front/composables/useValidator.ts
+++ b/front/composables/useValidator.ts
@@ -124,10 +124,10 @@ export const useValidator = () => {
 
   const passwordValidator = (
     dirty: ComputedRef<boolean>,
-    lastName: ComputedRef<string>,
+    password: ComputedRef<string>,
     t: any, //I18n
   ) => {
-    return validator(dirty, lastName, [
+    return validator(dirty, password, [
       requiredRule(t("Error.REQUIRED", { value: t("_Global.password") })),
       passwordRule(t("Error.INVALID_PASSWORD")),
     ]);

--- a/front/composables/useValidator.ts
+++ b/front/composables/useValidator.ts
@@ -91,10 +91,10 @@ export const useValidator = () => {
 
   const lastNameValidator = (
     dirty: ComputedRef<boolean>,
-    password: ComputedRef<string>,
+    lastName: ComputedRef<string>,
     t: any, //I18n
   ) => {
-    return validator(dirty, password, [
+    return validator(dirty, lastName, [
       requiredRule(t("Error.REQUIRED", { value: t("_Global.lastName") })),
       minLengthRule(
         t("Error.MIN_LENGTH", {

--- a/front/composables/useValidator.ts
+++ b/front/composables/useValidator.ts
@@ -70,9 +70,16 @@ export const useValidator = () => {
     dirty: ComputedRef<boolean>,
     firstName: ComputedRef<string>,
     t: any, //I18n
+<<<<<<< HEAD
   ) => {
     return validator(dirty, firstName, [
       requiredRule(t("Error.REQUIRED", { value: t("_Global.firstName") })),
+=======
+    pageModule: any,
+  ) => {
+    return validator(dirty, firstName, [
+      requiredRule(t("Error.REQUIRED", { value: pageModule })),
+>>>>>>> bed6999 (refactor: generate globally used validators for profile and account info)
       minLengthRule(
         t("Error.MIN_LENGTH", {
           value: t("_Global.firstName"),
@@ -94,6 +101,7 @@ export const useValidator = () => {
     t: any, //I18n
   ) => {
     return validator(dirty, lastName, [
+<<<<<<< HEAD
       requiredRule(t("Error.REQUIRED", { value: t("_Global.lastName") })),
       minLengthRule(
         t("Error.MIN_LENGTH", {
@@ -110,6 +118,12 @@ export const useValidator = () => {
     ]);
   };
 
+=======
+      requiredRule(t("Error.REQUIRED", { value: t("_Global.password") })),
+      passwordRule(t("Error.INVALID_PASSWORD")),
+    ]);
+  };
+>>>>>>> bed6999 (refactor: generate globally used validators for profile and account info)
   const emailValidator = (
     dirty: ComputedRef<boolean>,
     email: ComputedRef<string>,
@@ -128,7 +142,22 @@ export const useValidator = () => {
   ) => {
     return validator(dirty, password, [
       requiredRule(t("Error.REQUIRED", { value: t("_Global.password") })),
+<<<<<<< HEAD
       passwordRule(t("Error.INVALID_PASSWORD")),
+=======
+      minLengthRule(
+        t("Error.MIN_LENGTH", {
+          value: t("_Global.password"),
+          length: DEFAULT_MIN,
+        }),
+      ),
+      maxLengthRule(
+        t("Error.MAX_LENGTH", {
+          value: t("_Global.password"),
+          length: DEFAULT_MAX,
+        }),
+      ),
+>>>>>>> bed6999 (refactor: generate globally used validators for profile and account info)
     ]);
   };
 

--- a/front/langs/en.json
+++ b/front/langs/en.json
@@ -34,6 +34,11 @@
     "description": "Please check your mail box",
     "title": "Waiting for your email confirmation"
   },
+  "AuthForgotPassword": {
+    "title": "Forgot Password?",
+    "description": "Retrieve your account password using your registered email.",
+    "submit": "Submit"
+  },
   "Error": {
     "EMAIL_ALREADY_EXISTS": "Email already exists.",
     "GENERAL_ERROR": "Unexpected error",

--- a/front/langs/en.json
+++ b/front/langs/en.json
@@ -15,6 +15,7 @@
   "AuthLogin": {
     "login": "Login",
     "noAccount": "<p>You don't have an account yet?</p><p>Click <a class=\"text-primary-500 hover:text-primary-400 underline\" href=\"/en/auth/register\"> here </a> to register</p>",
+    "forgotPassword": "<p><a class=\"text-primary-500 hover:text-primary-400 underline\" href=\"/en/auth/forgot-password\"> Forgot password? </a></p>",
     "or": "OR",
     "title": "Login to get access"
   },

--- a/front/langs/en.json
+++ b/front/langs/en.json
@@ -12,10 +12,30 @@
     "title": "Email confirmed!",
     "watch": "Watch movie"
   },
+  "AuthForgotPassword": {
+    "changePassword": {
+      "button": "Submit",
+      "description": "Enter your new password below to complete the password change process.",
+      "title": "Change Password"
+    },
+    "complete": {
+      "button": "Click here to log in",
+      "description": "Your password has been successfully changed.",
+      "title": "Password Changed"
+    },
+    "description": "Retrieve your account password using your registered email.",
+    "emailSent": {
+      "button": "Back to Home",
+      "description": "We've sent you an email with instructions to reset your password. Please check your inbox.",
+      "title": "Password Change Email Sent"
+    },
+    "submit": "Submit",
+    "title": "Forgot Password?"
+  },
   "AuthLogin": {
+    "forgotPassword": "<p><a class=\"text-primary-500 hover:text-primary-400 underline\" href=\"/en/auth/forgot-password\"> Forgot password? </a></p>",
     "login": "Login",
     "noAccount": "<p>You don't have an account yet?</p><p>Click <a class=\"text-primary-500 hover:text-primary-400 underline\" href=\"/en/auth/register\"> here </a> to register</p>",
-    "forgotPassword": "<p><a class=\"text-primary-500 hover:text-primary-400 underline\" href=\"/en/auth/forgot-password\"> Forgot password? </a></p>",
     "or": "OR",
     "title": "Login to get access"
   },
@@ -33,26 +53,6 @@
   "AuthVerifyEmail": {
     "description": "Please check your mail box",
     "title": "Waiting for your email confirmation"
-  },
-  "AuthForgotPassword": {
-    "title": "Forgot Password?",
-    "description": "Retrieve your account password using your registered email.",
-    "submit": "Submit",
-    "emailSent": {
-      "title": "Password Change Email Sent",
-      "description": "We've sent you an email with instructions to reset your password. Please check your inbox.",
-      "button": "Back to Home"
-    },
-    "changePassword": {
-      "title": "Change Password",
-      "description": "Enter your new password below to complete the password change process.",
-      "button": "Submit"
-    },
-    "complete": {
-      "title": "Password Changed",
-      "description": "Your password has been successfully changed.",
-      "button": "Click here to log in"
-    }
   },
   "Error": {
     "EMAIL_ALREADY_EXISTS": "Email already exists.",

--- a/front/langs/en.json
+++ b/front/langs/en.json
@@ -37,7 +37,12 @@
   "AuthForgotPassword": {
     "title": "Forgot Password?",
     "description": "Retrieve your account password using your registered email.",
-    "submit": "Submit"
+    "submit": "Submit",
+    "emailSent": {
+      "title": "Password Change Email Sent",
+      "description": "We've sent you an email with instructions to reset your password. Please check your inbox.",
+      "button": "Back to Home"
+    }
   },
   "Error": {
     "EMAIL_ALREADY_EXISTS": "Email already exists.",

--- a/front/langs/en.json
+++ b/front/langs/en.json
@@ -42,6 +42,11 @@
       "title": "Password Change Email Sent",
       "description": "We've sent you an email with instructions to reset your password. Please check your inbox.",
       "button": "Back to Home"
+    },
+    "changePassword": {
+      "title": "Change Password",
+      "description": "Enter your new password below to complete the password change process.",
+      "button": "Submit"
     }
   },
   "Error": {

--- a/front/langs/en.json
+++ b/front/langs/en.json
@@ -47,6 +47,11 @@
       "title": "Change Password",
       "description": "Enter your new password below to complete the password change process.",
       "button": "Submit"
+    },
+    "complete": {
+      "title": "Password Changed",
+      "description": "Your password has been successfully changed.",
+      "button": "Click here to log in"
     }
   },
   "Error": {

--- a/front/langs/en.json
+++ b/front/langs/en.json
@@ -16,10 +16,11 @@
     "changePassword": {
       "button": "Submit",
       "description": "Enter your new password below to complete the password change process.",
-      "title": "Change Password"
+      "title": "Change Password",
+      "confirm": "Confirm"
     },
     "complete": {
-      "button": "Click here to log in",
+      "button": "Back to Home",
       "description": "Your password has been successfully changed.",
       "title": "Password Changed"
     },

--- a/front/langs/en.json
+++ b/front/langs/en.json
@@ -15,9 +15,9 @@
   "AuthForgotPassword": {
     "changePassword": {
       "button": "Submit",
+      "confirm": "Confirm",
       "description": "Enter your new password below to complete the password change process.",
-      "title": "Change Password",
-      "confirm": "Confirm"
+      "title": "Change Password"
     },
     "complete": {
       "button": "Back to Home",
@@ -61,12 +61,12 @@
     "INVALID_EMAIL": "Invalid email address",
     "INVALID_LOGIN": "Invalid username or password",
     "INVALID_PASSWORD": "Password must be at least 8 characters long and include an uppercase letter, a lowercase letter, a digit, and a special character.",
+    "INVALID_USER_CREDENTIALS": "Invalid user credentials.",
     "MAX_LENGTH": "{value} must be less than {length}",
     "MIN_LENGTH": "{value} must be at least {length} characters long.",
     "PASSWORD_DOES_NOT_MATCH": "Password does not match.",
     "REQUIRED": " {value} is required",
-    "USERNAME_ALREADY_EXISTS": "Username already exists.",
-    "INVALID_USER_CREDENTIALS": "Invalid user credentials."
+    "USERNAME_ALREADY_EXISTS": "Username already exists."
   },
   "Footer": {
     "copyright": "All Rights Reserved."
@@ -103,8 +103,8 @@
       "title": "Profile"
     },
     "WatchedList": {
-      "title": "Watched list",
-      "noList": "You haven't watched any movie yet."
+      "noList": "You haven't watched any movie yet.",
+      "title": "Watched list"
     }
   }
 }

--- a/front/langs/en.json
+++ b/front/langs/en.json
@@ -64,7 +64,8 @@
     "MIN_LENGTH": "{value} must be at least {length} characters long.",
     "PASSWORD_DOES_NOT_MATCH": "Password does not match.",
     "REQUIRED": " {value} is required",
-    "USERNAME_ALREADY_EXISTS": "Username already exists."
+    "USERNAME_ALREADY_EXISTS": "Username already exists.",
+    "INVALID_USER_CREDENTIALS": "Invalid user credentials."
   },
   "Footer": {
     "copyright": "All Rights Reserved."

--- a/front/langs/fr.json
+++ b/front/langs/fr.json
@@ -88,6 +88,11 @@
   },
   "AuthForgotPassword": {
     "title": "Mot de passe oublié?",
-    "submit": "Soumettre"
+    "submit": "Soumettre",
+    "emailSent": {
+      "title": "E-mail de changement de mot de passe envoyé",
+      "description": "Nous vous avons envoyé un e-mail contenant des instructions pour réinitialiser votre mot de passe. \nVeuillez vérifier votre boîte de réception.",
+      "button": "De retour à la maison"
+    }
   }
 }

--- a/front/langs/fr.json
+++ b/front/langs/fr.json
@@ -12,12 +12,31 @@
     "title": "E-mail confirmé !",
     "watch": "Regarder un film"
   },
+  "AuthForgotPassword": {
+    "changePassword": {
+      "button": "Soumettre",
+      "description": "Entrez votre nouveau mot de passe ci-dessous pour terminer le processus de changement de mot de passe.",
+      "title": "Changer le mot de passe"
+    },
+    "complete": {
+      "button": "Cliquez ici pour vous identifier",
+      "description": "Votre mot de passe a été changé avec succès.",
+      "title": "Mot de passe changé"
+    },
+    "emailSent": {
+      "button": "De retour à la maison",
+      "description": "Nous vous avons envoyé un e-mail contenant des instructions pour réinitialiser votre mot de passe. \nVeuillez vérifier votre boîte de réception.",
+      "title": "E-mail de changement de mot de passe envoyé"
+    },
+    "submit": "Soumettre",
+    "title": "Mot de passe oublié?"
+  },
   "AuthLogin": {
+    "forgotPassword": "<p><a class=\"text-primary-500 hover:text-primary-400 underline\" href=\"/fr/auth/forgot-password\"> Mot de passe oublié ? \n</a></p>",
     "login": "Se connecter",
     "noAccount": "<p>Vous n'avez pas de compte ?</p><p>Cliquez <a class=\"text-primary-500 hover:text-primary-400 underline\" href=\"/fr/auth/register\"> ici </a> pour vous inscrire</p>",
     "or": "OU",
-    "title": "Connectez-vous pour accéder",
-    "forgotPassword": "<p><a class=\"text-primary-500 hover:text-primary-400 underline\" href=\"/fr/auth/forgot-password\"> Mot de passe oublié ? \n</a></p>"
+    "title": "Connectez-vous pour accéder"
   },
   "AuthRegister": {
     "description": "Créez un compte pour profiter de films en illimité",
@@ -84,15 +103,6 @@
     "WatchedList": {
       "title": "Liste déjà vu",
       "noList": "Vous n'avez jamais vu aucun film."
-    }
-  },
-  "AuthForgotPassword": {
-    "title": "Mot de passe oublié?",
-    "submit": "Soumettre",
-    "emailSent": {
-      "title": "E-mail de changement de mot de passe envoyé",
-      "description": "Nous vous avons envoyé un e-mail contenant des instructions pour réinitialiser votre mot de passe. \nVeuillez vérifier votre boîte de réception.",
-      "button": "De retour à la maison"
     }
   }
 }

--- a/front/langs/fr.json
+++ b/front/langs/fr.json
@@ -85,5 +85,9 @@
       "title": "Liste déjà vu",
       "noList": "Vous n'avez jamais vu aucun film."
     }
+  },
+  "AuthForgotPassword": {
+    "title": "Mot de passe oublié?",
+    "submit": "Soumettre"
   }
 }

--- a/front/langs/fr.json
+++ b/front/langs/fr.json
@@ -16,7 +16,8 @@
     "login": "Se connecter",
     "noAccount": "<p>Vous n'avez pas de compte ?</p><p>Cliquez <a class=\"text-primary-500 hover:text-primary-400 underline\" href=\"/fr/auth/register\"> ici </a> pour vous inscrire</p>",
     "or": "OU",
-    "title": "Connectez-vous pour accéder"
+    "title": "Connectez-vous pour accéder",
+    "forgotPassword": "<p><a class=\"text-primary-500 hover:text-primary-400 underline\" href=\"/fr/auth/forgot-password\"> Mot de passe oublié ? \n</a></p>"
   },
   "AuthRegister": {
     "description": "Créez un compte pour profiter de films en illimité",

--- a/front/langs/fr.json
+++ b/front/langs/fr.json
@@ -16,7 +16,8 @@
     "changePassword": {
       "button": "Soumettre",
       "description": "Entrez votre nouveau mot de passe ci-dessous pour terminer le processus de changement de mot de passe.",
-      "title": "Changer le mot de passe"
+      "title": "Changer le mot de passe",
+      "confirm": "Confirmer"
     },
     "complete": {
       "button": "Cliquez ici pour vous identifier",

--- a/front/langs/fr.json
+++ b/front/langs/fr.json
@@ -15,23 +15,23 @@
   "AuthForgotPassword": {
     "changePassword": {
       "button": "Soumettre",
+      "confirm": "Confirmer",
       "description": "Entrez votre nouveau mot de passe ci-dessous pour terminer le processus de changement de mot de passe.",
-      "title": "Changer le mot de passe",
-      "confirm": "Confirmer"
+      "title": "Changer le mot de passe"
     },
     "complete": {
       "button": "Cliquez ici pour vous identifier",
       "description": "Votre mot de passe a été changé avec succès.",
       "title": "Mot de passe changé"
     },
+    "description": "Récupérez le mot de passe de votre compte en utilisant votre e-mail enregistré.",
     "emailSent": {
       "button": "De retour à la maison",
       "description": "Nous vous avons envoyé un e-mail contenant des instructions pour réinitialiser votre mot de passe. \nVeuillez vérifier votre boîte de réception.",
       "title": "E-mail de changement de mot de passe envoyé"
     },
     "submit": "Soumettre",
-    "title": "Mot de passe oublié?",
-    "description": "Récupérez le mot de passe de votre compte en utilisant votre e-mail enregistré."
+    "title": "Mot de passe oublié?"
   },
   "AuthLogin": {
     "forgotPassword": "<p><a class=\"text-primary-500 hover:text-primary-400 underline\" href=\"/fr/auth/forgot-password\"> Mot de passe oublié ? \n</a></p>",
@@ -61,12 +61,12 @@
     "INVALID_EMAIL": "Adresse email invalide",
     "INVALID_LOGIN": "Nom d'utilisateur ou mot de passe invalide",
     "INVALID_PASSWORD": "Le mot de passe doit avoir au moins 8 caractères et contenir une lettre majuscule, une lettre minuscule, un chiffre et un caractère spécial.",
+    "INVALID_USER_CREDENTIALS": "Identifiants utilisateur invalides.",
     "MAX_LENGTH": "{value} doit comporter mois de {length} caractères",
     "MIN_LENGTH": "{value} doit comporter au moins {length} caractères.",
     "PASSWORD_DOES_NOT_MATCH": "Le mot de passe ne correspond pas.",
     "REQUIRED": "{value} est obligatoire",
-    "USERNAME_ALREADY_EXISTS": "Le nom d'utilisateur existe déjà.",
-    "INVALID_USER_CREDENTIALS": "Identifiants utilisateur invalides."
+    "USERNAME_ALREADY_EXISTS": "Le nom d'utilisateur existe déjà."
   },
   "Footer": {
     "copyright": "Tous droits réservés."
@@ -104,8 +104,8 @@
       "title": "Profil"
     },
     "WatchedList": {
-      "title": "Liste déjà vu",
-      "noList": "Vous n'avez jamais vu aucun film."
+      "noList": "Vous n'avez jamais vu aucun film.",
+      "title": "Liste déjà vu"
     }
   }
 }

--- a/front/langs/fr.json
+++ b/front/langs/fr.json
@@ -20,13 +20,13 @@
       "title": "Changer le mot de passe"
     },
     "complete": {
-      "button": "Cliquez ici pour vous identifier",
+      "button": "Retour à l'accueil",
       "description": "Votre mot de passe a été changé avec succès.",
       "title": "Mot de passe changé"
     },
     "description": "Récupérez le mot de passe de votre compte en utilisant votre e-mail enregistré.",
     "emailSent": {
-      "button": "De retour à la maison",
+      "button": "Retour à l'accueil",
       "description": "Nous vous avons envoyé un e-mail contenant des instructions pour réinitialiser votre mot de passe. \nVeuillez vérifier votre boîte de réception.",
       "title": "E-mail de changement de mot de passe envoyé"
     },

--- a/front/langs/fr.json
+++ b/front/langs/fr.json
@@ -29,7 +29,8 @@
       "title": "E-mail de changement de mot de passe envoyé"
     },
     "submit": "Soumettre",
-    "title": "Mot de passe oublié?"
+    "title": "Mot de passe oublié?",
+    "description": "Récupérez le mot de passe de votre compte en utilisant votre e-mail enregistré."
   },
   "AuthLogin": {
     "forgotPassword": "<p><a class=\"text-primary-500 hover:text-primary-400 underline\" href=\"/fr/auth/forgot-password\"> Mot de passe oublié ? \n</a></p>",
@@ -63,7 +64,8 @@
     "MIN_LENGTH": "{value} doit comporter au moins {length} caractères.",
     "PASSWORD_DOES_NOT_MATCH": "Le mot de passe ne correspond pas.",
     "REQUIRED": "{value} est obligatoire",
-    "USERNAME_ALREADY_EXISTS": "Le nom d'utilisateur existe déjà."
+    "USERNAME_ALREADY_EXISTS": "Le nom d'utilisateur existe déjà.",
+    "INVALID_USER_CREDENTIALS": "Identifiants utilisateur invalides."
   },
   "Footer": {
     "copyright": "Tous droits réservés."

--- a/front/layouts/password-change.vue
+++ b/front/layouts/password-change.vue
@@ -2,7 +2,7 @@
 <template>
   <TheNavbar />
   <main
-    class="flex min-h-[calc(100vh-64px)] flex-col items-center justify-center bg-slate-900 px-4 pb-32 pt-[112px] lg:p-8 lg:pt-[112px]"
+    class="flex min-h-[calc(100vh-64px)] flex-col items-center justify-center bg-slate-900 px-4 pb-32 pt-[92px] lg:p-8 lg:pt-[92px]"
   >
     <slot />
   </main>

--- a/front/layouts/password-change.vue
+++ b/front/layouts/password-change.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts"></script>
+<template>
+  <TheNavbar />
+  <main
+    class="flex min-h-[calc(100vh-64px)] flex-col items-center justify-center bg-slate-900 px-4 pb-32 pt-[112px] lg:p-8 lg:pt-[112px]"
+  >
+    <slot />
+  </main>
+  <TheFooter />
+</template>

--- a/front/pages/auth/forgot-password.vue
+++ b/front/pages/auth/forgot-password.vue
@@ -1,11 +1,66 @@
+<script setup>
+definePageMeta({
+  layout: "auth",
+  middleware: ["non-auth"],
+});
+
+// const axios = useAxios();
+
+const email = ref("");
+const localePath = useLocalePath();
+const { emailValidator } = useValidator();
+const { t } = useI18n();
+// const loading = ref(false);
+const dirty = ref(false);
+const { error: errorEmail } = emailValidator(dirty, email, t);
+
+const handleOnSubmit = async () => {
+  dirty.value = true;
+  if (errorEmail.value) return;
+
+  try {
+    loading.value = true;
+    await navigateTo({ path: localePath("auth-verify-email") });
+    errorGlobal.value = "";
+  } catch (e) {
+    if (e.response && e.response.data.code) {
+      errorGlobal.value = t(`Error.${e.response.data.code}`);
+    } else {
+      errorGlobal.value = t(`Error.GENERAL_ERROR`);
+    }
+  } finally {
+    loading.value = false;
+  }
+};
+</script>
+
 <template>
   <main
     class="flex min-h-[calc(100vh-64px)] justify-center bg-slate-900 p-4 pt-[112px] lg:p-8 lg:pt-[112px]"
   >
     <div class="mt-10 flex w-full max-w-[450px] flex-col items-center gap-4">
       <h1 class="text-center text-2xl font-[800] md:text-4xl lg:mb-10">
-        {{ $t("AuthLogin.title") }}
+        {{ $t("AuthForgotPassword.title") }}
       </h1>
+      <div class="flex w-full items-center gap-3">
+        {{ $t("AuthForgotPassword.description") }}
+      </div>
+      <section class="flex w-full flex-col text-center">
+        <form class="grid max-w-[450px] gap-3" @submit.prevent="handleOnSubmit">
+          <BaseInput
+            v-model="email"
+            type="email"
+            :label="$t('_Global.email')"
+            autocomplete="email"
+            class="sm:col-span-2"
+            :error-message="errorEmail"
+            :error="!!errorGlobal"
+          />
+          <Button class="mt-4 w-full sm:col-span-2" type="submit">
+            {{ $t("AuthForgotPassword.submit") }}
+          </Button>
+        </form>
+      </section>
     </div>
   </main>
 </template>

--- a/front/pages/auth/forgot-password.vue
+++ b/front/pages/auth/forgot-password.vue
@@ -1,22 +1,26 @@
 <script setup>
 definePageMeta({
-  layout: "auth",
+  layout: "password-change",
   middleware: ["non-auth"],
 });
 
 // const axios = useAxios();
 
+const username = ref("");
 const email = ref("");
 const localePath = useLocalePath();
-const { emailValidator } = useValidator();
+const { emailValidator, usernameValidator } = useValidator();
 const { t } = useI18n();
-// const loading = ref(false);
+const loading = ref(false);
 const dirty = ref(false);
 const { error: errorEmail } = emailValidator(dirty, email, t);
+const { error: errorUsername } = usernameValidator(dirty, username, t);
+const errorGlobal = ref("");
+// const { locale } = useI18n();
 
 const handleOnSubmit = async () => {
   dirty.value = true;
-  if (errorEmail.value) return;
+  if (errorEmail.value || errorUsername.value) return;
 
   try {
     loading.value = true;
@@ -45,8 +49,18 @@ const handleOnSubmit = async () => {
       <div class="flex w-full items-center gap-3">
         {{ $t("AuthForgotPassword.description") }}
       </div>
+      <br />
       <section class="flex w-full flex-col text-center">
         <form class="grid max-w-[450px] gap-3" @submit.prevent="handleOnSubmit">
+          <BaseInput
+            v-model="username"
+            type="text"
+            :label="$t('_Global.username')"
+            class="sm:col-span-2"
+            autocomplete="username"
+            :error-message="errorUsername"
+            :error="!!errorGlobal"
+          />
           <BaseInput
             v-model="email"
             type="email"
@@ -56,9 +70,15 @@ const handleOnSubmit = async () => {
             :error-message="errorEmail"
             :error="!!errorGlobal"
           />
-          <Button class="mt-4 w-full sm:col-span-2" type="submit">
-            {{ $t("AuthForgotPassword.submit") }}
-          </Button>
+          <Button
+            class="mt-4 w-full sm:col-span-2"
+            type="submit"
+            :label="loading ? null : $t('AuthForgotPassword.submit')"
+            :loading="loading"
+          />
+          <small v-if="dirty && errorGlobal" class="mt-2 text-lg text-red-500">
+            {{ errorGlobal }}
+          </small>
         </form>
       </section>
     </div>

--- a/front/pages/auth/forgot-password.vue
+++ b/front/pages/auth/forgot-password.vue
@@ -8,8 +8,10 @@ definePageMeta({
 
 const username = ref("");
 const email = ref("");
-const localePath = useLocalePath();
+const axios = useAxios();
+// const localePath = useLocalePath();
 const { emailValidator, usernameValidator } = useValidator();
+const { doCheckUserCredentials } = useAuth();
 const { t } = useI18n();
 const loading = ref(false);
 const dirty = ref(false);
@@ -24,7 +26,11 @@ const handleOnSubmit = async () => {
 
   try {
     loading.value = true;
-    await navigateTo({ path: localePath("auth-verify-email") });
+    await doCheckUserCredentials(axios, {
+      username: username.value,
+      email: email.value,
+    });
+    // await navigateTo({ path: localePath("auth-verify-email") });
     errorGlobal.value = "";
   } catch (e) {
     if (e.response && e.response.data.code) {

--- a/front/pages/auth/forgot-password.vue
+++ b/front/pages/auth/forgot-password.vue
@@ -1,0 +1,11 @@
+<template>
+  <main
+    class="flex min-h-[calc(100vh-64px)] justify-center bg-slate-900 p-4 pt-[112px] lg:p-8 lg:pt-[112px]"
+  >
+    <div class="mt-10 flex w-full max-w-[450px] flex-col items-center gap-4">
+      <h1 class="text-center text-2xl font-[800] md:text-4xl lg:mb-10">
+        {{ $t("AuthLogin.title") }}
+      </h1>
+    </div>
+  </main>
+</template>

--- a/front/pages/auth/forgot-password.vue
+++ b/front/pages/auth/forgot-password.vue
@@ -9,7 +9,7 @@ definePageMeta({
 const username = ref("");
 const email = ref("");
 const axios = useAxios();
-// const localePath = useLocalePath();
+const localePath = useLocalePath();
 const { emailValidator, usernameValidator } = useValidator();
 const { doCheckUserCredentials } = useAuth();
 const { t } = useI18n();
@@ -18,7 +18,7 @@ const dirty = ref(false);
 const { error: errorEmail } = emailValidator(dirty, email, t);
 const { error: errorUsername } = usernameValidator(dirty, username, t);
 const errorGlobal = ref("");
-// const { locale } = useI18n();
+const { locale } = useI18n();
 
 const handleOnSubmit = async () => {
   dirty.value = true;
@@ -26,11 +26,15 @@ const handleOnSubmit = async () => {
 
   try {
     loading.value = true;
-    await doCheckUserCredentials(axios, {
-      username: username.value,
-      email: email.value,
-    });
-    // await navigateTo({ path: localePath("auth-verify-email") });
+    await doCheckUserCredentials(
+      axios,
+      {
+        username: username.value,
+        email: email.value,
+      },
+      locale.value,
+    );
+    await navigateTo({ path: localePath("auth-password-email-sent") });
     errorGlobal.value = "";
   } catch (e) {
     if (e.response && e.response.data.code) {

--- a/front/pages/auth/login.vue
+++ b/front/pages/auth/login.vue
@@ -117,6 +117,7 @@ const onLogin = async () => {
         </form>
 
         <div class="mt-5" v-html="$t('AuthLogin.noAccount')" />
+        <div class="mt-5" v-html="$t('AuthLogin.forgotPassword')" />
       </section>
     </div>
   </main>

--- a/front/pages/auth/password-email-change.vue
+++ b/front/pages/auth/password-email-change.vue
@@ -56,7 +56,7 @@ const handleOnSubmit = async () => {
 </script>
 
 <template>
-  <div class="mt-10 flex w-full max-w-[450px] flex-col items-center gap-4">
+  <div class="mt-[-10] flex w-full max-w-[450px] flex-col items-center gap-4">
     <h1 class="text-center text-3xl font-[800] sm:text-4xl lg:mb-10">
       {{ $t("AuthForgotPassword.changePassword.title") }}
     </h1>

--- a/front/pages/auth/password-email-change.vue
+++ b/front/pages/auth/password-email-change.vue
@@ -1,0 +1,72 @@
+<script setup>
+definePageMeta({
+  layout: "password-change",
+  middleware: ["non-auth"],
+});
+
+const password = ref("");
+const { passwordValidator } = useValidator();
+const { t } = useI18n();
+const loading = ref(false);
+const dirty = ref(false);
+const { error: errorPassword } = passwordValidator(dirty, password, t);
+const errorGlobal = ref("");
+
+const handleOnSubmit = async () => {
+  dirty.value = true;
+  if (errorPassword.value) return;
+
+  try {
+    loading.value = true;
+    await doCheckUserCredentials(axios, {
+      username: username.value,
+      email: email.value,
+    });
+    // await navigateTo({ path: localePath("auth-verify-email") });
+    errorGlobal.value = "";
+  } catch (e) {
+    if (e.response && e.response.data.code) {
+      errorGlobal.value = t(`Error.${e.response.data.code}`);
+    } else {
+      errorGlobal.value = t(`Error.GENERAL_ERROR`);
+    }
+  } finally {
+    loading.value = false;
+  }
+};
+</script>
+
+<template>
+  <div class="mt-10 flex w-full max-w-[450px] flex-col items-center gap-4">
+    <h1 class="text-center text-3xl font-[800] sm:text-4xl lg:mb-10">
+      {{ $t("AuthForgotPassword.changePassword.title") }}
+    </h1>
+    <p class="text-center text-2xl text-gray-400">
+      {{ $t("AuthForgotPassword.changePassword.description") }}
+    </p>
+    <section class="flex w-full flex-col text-center">
+      <form class="grid max-w-[450px] gap-3" @submit.prevent="handleOnSubmit">
+        <BaseInput
+          v-model="password"
+          type="password"
+          :label="$t('_Global.password')"
+          autocomplete="password"
+          class="sm:col-span-2"
+          :error-message="errorPassword"
+          :error="!!errorGlobal"
+        />
+        <Button
+          class="mt-4 w-full sm:col-span-2"
+          type="submit"
+          :label="
+            loading ? null : $t('AuthForgotPassword.changePassword.button')
+          "
+          :loading="loading"
+        />
+        <small v-if="dirty && errorGlobal" class="mt-2 text-lg text-red-500">
+          {{ errorGlobal }}
+        </small>
+      </form>
+    </section>
+  </div>
+</template>

--- a/front/pages/auth/password-email-complete.vue
+++ b/front/pages/auth/password-email-complete.vue
@@ -1,7 +1,7 @@
 <script setup>
 definePageMeta({
   layout: "password-change",
-  middleware: ["non-auth"],
+  middleware: ["strict-auth"],
 });
 </script>
 
@@ -14,7 +14,7 @@ definePageMeta({
       {{ $t("AuthForgotPassword.complete.description") }}
     </p>
     <div>
-      <NuxtLink :to="localePath('/auth/login')">
+      <NuxtLink :to="localePath('/')">
         <Button :label="$t('AuthForgotPassword.complete.button')" />
       </NuxtLink>
     </div>

--- a/front/pages/auth/password-email-complete.vue
+++ b/front/pages/auth/password-email-complete.vue
@@ -1,0 +1,22 @@
+<script setup>
+definePageMeta({
+  layout: "password-change",
+  middleware: ["non-auth"],
+});
+</script>
+
+<template>
+  <div class="mt-10 flex w-full max-w-[450px] flex-col items-center gap-4">
+    <h1 class="text-center text-3xl font-[800] sm:text-4xl lg:mb-10">
+      {{ $t("AuthForgotPassword.complete.title") }}
+    </h1>
+    <p class="text-center text-2xl text-gray-400">
+      {{ $t("AuthForgotPassword.complete.description") }}
+    </p>
+    <div>
+      <NuxtLink :to="localePath('/auth/login')">
+        <Button :label="$t('AuthForgotPassword.complete.button')" />
+      </NuxtLink>
+    </div>
+  </div>
+</template>

--- a/front/pages/auth/password-email-complete.vue
+++ b/front/pages/auth/password-email-complete.vue
@@ -6,14 +6,14 @@ definePageMeta({
 </script>
 
 <template>
-  <div class="mt-10 flex w-full max-w-[450px] flex-col items-center gap-4">
+  <div class="mt-5 flex w-full max-w-[450px] flex-col items-center gap-4">
     <h1 class="text-center text-3xl font-[800] sm:text-4xl lg:mb-10">
       {{ $t("AuthForgotPassword.complete.title") }}
     </h1>
     <p class="text-center text-2xl text-gray-400">
       {{ $t("AuthForgotPassword.complete.description") }}
     </p>
-    <div>
+    <div class="mt-10">
       <NuxtLink :to="localePath('/')">
         <Button :label="$t('AuthForgotPassword.complete.button')" />
       </NuxtLink>

--- a/front/pages/auth/password-email-sent.vue
+++ b/front/pages/auth/password-email-sent.vue
@@ -1,0 +1,22 @@
+<script setup>
+definePageMeta({
+  layout: "password-change",
+  middleware: ["non-auth"],
+});
+</script>
+
+<template>
+  <div class="mt-10 flex w-full max-w-[450px] flex-col items-center gap-4">
+    <h1 class="text-center text-3xl font-[800] sm:text-4xl lg:mb-10">
+      {{ $t("AuthForgotPassword.emailSent.title") }}
+    </h1>
+    <p class="text-center text-2xl text-gray-400">
+      {{ $t("AuthForgotPassword.emailSent.description") }}
+    </p>
+    <div>
+      <NuxtLink :to="localePath('index')">
+        <Button :label="$t('AuthForgotPassword.emailSent.button')" />
+      </NuxtLink>
+    </div>
+  </div>
+</template>

--- a/front/pages/auth/password-email-sent.vue
+++ b/front/pages/auth/password-email-sent.vue
@@ -6,14 +6,14 @@ definePageMeta({
 </script>
 
 <template>
-  <div class="mt-10 flex w-full max-w-[450px] flex-col items-center gap-4">
+  <div class="mt-5 flex w-full max-w-[600px] flex-col items-center gap-4">
     <h1 class="text-center text-3xl font-[800] sm:text-4xl lg:mb-10">
       {{ $t("AuthForgotPassword.emailSent.title") }}
     </h1>
     <p class="text-center text-2xl text-gray-400">
       {{ $t("AuthForgotPassword.emailSent.description") }}
     </p>
-    <div>
+    <div class="mt-10">
       <NuxtLink :to="localePath('index')">
         <Button :label="$t('AuthForgotPassword.emailSent.button')" />
       </NuxtLink>

--- a/front/pages/auth/register.vue
+++ b/front/pages/auth/register.vue
@@ -32,10 +32,6 @@ const { error: errorEmail } = emailValidator(dirty, email, t);
 const { error: errorPassword } = passwordValidator(dirty, password, t);
 const errorGlobal = ref("");
 
-const browserLanguage = process.client
-  ? navigator.language.toLowerCase()
-  : "en";
-const locale = browserLanguage.startsWith("fr") ? "fr" : "en";
 
 // TODO: Validation and show error message
 const handleOnSubmit = async () => {
@@ -59,9 +55,7 @@ const handleOnSubmit = async () => {
 
   try {
     loading.value = true;
-
     await doRegister(axios, userInfo, locale.value);
-
     await navigateTo({ path: localePath("auth-verify-email") });
     errorGlobal.value = "";
   } catch (e) {

--- a/front/pages/auth/register.vue
+++ b/front/pages/auth/register.vue
@@ -32,7 +32,6 @@ const { error: errorEmail } = emailValidator(dirty, email, t);
 const { error: errorPassword } = passwordValidator(dirty, password, t);
 const errorGlobal = ref("");
 
-
 // TODO: Validation and show error message
 const handleOnSubmit = async () => {
   dirty.value = true;
@@ -55,7 +54,7 @@ const handleOnSubmit = async () => {
 
   try {
     loading.value = true;
-    await doRegister(axios, userInfo, locale.value);
+    await doRegister(axios, userInfo, locale);
     await navigateTo({ path: localePath("auth-verify-email") });
     errorGlobal.value = "";
   } catch (e) {

--- a/front/pages/auth/register.vue
+++ b/front/pages/auth/register.vue
@@ -31,6 +31,7 @@ const { error: errorLastName } = lastNameValidator(dirty, lastName, t);
 const { error: errorEmail } = emailValidator(dirty, email, t);
 const { error: errorPassword } = passwordValidator(dirty, password, t);
 const errorGlobal = ref("");
+const { locale } = useI18n();
 
 // TODO: Validation and show error message
 const handleOnSubmit = async () => {
@@ -54,7 +55,7 @@ const handleOnSubmit = async () => {
 
   try {
     loading.value = true;
-    await doRegister(axios, userInfo, locale);
+    await doRegister(axios, userInfo, locale.value);
     await navigateTo({ path: localePath("auth-verify-email") });
     errorGlobal.value = "";
   } catch (e) {
@@ -145,9 +146,12 @@ const handleOnSubmit = async () => {
           :error-message="errorPassword"
           :error="!!errorGlobal"
         />
-        <Button class="mt-4 w-full sm:col-span-2" type="submit">
-          {{ $t("AuthRegister.register") }}
-        </Button>
+        <Button
+          class="mt-4 w-full sm:col-span-2"
+          type="submit"
+          :label="loading ? null : $t('AuthRegister.register')"
+          :loading="loading"
+        />
         <small v-if="dirty && errorGlobal" class="mt-2 text-lg text-red-500">
           {{ errorGlobal }}
         </small>

--- a/front/stores/user.store.ts
+++ b/front/stores/user.store.ts
@@ -8,7 +8,7 @@ export const useUserStore = defineStore("user", () => {
   const isLoggedIn = computed(() => !!userData.value.accessToken);
   const isEmailVerified = computed(() => userData.value.emailVerified);
   const userImage = computed(() => {
-    return userData.value?.image ?? defaultAvatar;
+    return userData.value?.image || defaultAvatar;
   });
 
   return {


### PR DESCRIPTION
Forgot password 발송기능을 구현 하였습니다.

1. login 페이지에서 하단에 forgot password? 링크로 이동
2. username 과 이메일을 입력 받음 (에러처리 되어있음)
(버튼 클릭후) 3. 등록된 이메일로 비밀번호 변경 이메일 발송
4. 비밀번호 변경 진행 (참고: 이 상태에서 이미 로그인이 되어있음)
5. 비밀번호 변경 확인페이지로 이동

개발 진행시 이슈가 되었던 부분은 대화방에 자세하게 남겨놓았으니 확인 부탁드립니다.

코드리뷰는 @woolimi 님과 이미 진행하여 기능구현에는 문제가 없고 
(디자인은 나름 만져보았는데...... 수정 할 필요가 없다면) 
바로 머지 하면 될것 같습니다.

close: #41 