### PR TITLE
이메일 쿼리 DB 저장후 검증

### DIFF
--- a/back/src/auth/email.service.ts
+++ b/back/src/auth/email.service.ts
@@ -95,6 +95,7 @@ export class EmailService {
       await this.transporter.sendMail(mailOptions);
       Logger.log('Password reset email sent to ' + data.email);
       Logger.log(template[lang].html);
+      return token;
     } catch (error) {
       throw new ServiceUnavailableException("Can't send password reset email");
     }

--- a/back/src/auth/email.service.ts
+++ b/back/src/auth/email.service.ts
@@ -31,6 +31,7 @@ export class EmailService {
         expiresIn: `${24 * 60 * 60}s`, // 24 hours
       },
     );
+
     const template = {
       en: {
         subject: 'Verify your email',
@@ -54,6 +55,7 @@ export class EmailService {
       await this.transporter.sendMail(mailOptions);
       Logger.log('Email sent to ' + data.email);
       Logger.log(template[lang].html);
+      return token;
     } catch (error) {
       throw new ServiceUnavailableException("Can't send email");
     }

--- a/back/src/user/dto/update-user.dto.ts
+++ b/back/src/user/dto/update-user.dto.ts
@@ -34,14 +34,17 @@ export class UpdateUserDto {
   password?: string;
 
   @IsOptional()
-  @IsOptional()
   image?: string;
 
-  @IsOptional()
   @IsOptional()
   provider?: string;
 
   @IsOptional()
-  @IsOptional()
   emailVerified?: boolean;
+
+  @IsOptional()
+  emailVerifyToken?: string;
+
+  @IsOptional()
+  passwordVerifyToken?: string;
 }

--- a/back/src/user/user.entity.ts
+++ b/back/src/user/user.entity.ts
@@ -69,6 +69,12 @@ export class User {
   @Column({ default: 'local' })
   provider: string;
 
+  @Column({ default: '' })
+  emailVerifyToken: string;
+
+  @Column({ default: '' })
+  passwordVerifyToken: string;
+
   @CreateDateColumn()
   createdAt: Date;
 

--- a/back/src/user/user.service.ts
+++ b/back/src/user/user.service.ts
@@ -12,13 +12,8 @@ export class UserService {
   constructor(
     @InjectRepository(User)
     private readonly userRepository: Repository<User>,
-<<<<<<< HEAD
     private connection: DataSource,
-  ) {}
-=======
-    private connection: Connection,
   ) { }
->>>>>>> 28b1c6e (feat: email verify token saved and verify, add validations)
 
   async findAll(): Promise<User[]> {
     return this.userRepository.find();

--- a/back/src/user/user.service.ts
+++ b/back/src/user/user.service.ts
@@ -99,6 +99,12 @@ export class UserService {
   async update(id: string, user: UpdateUserDto): Promise<UpdateResult> {
     if (user.password) {
       user.password = await this.cryptPassword(user.password);
+      const passwordTokenCheckUser = await this.userRepository.findOneBy({
+        id,
+      });
+
+      if (passwordTokenCheckUser.passwordVerifyToken)
+        user.passwordVerifyToken = '';
     }
 
     let duplicateUsername;
@@ -130,6 +136,12 @@ export class UserService {
     });
   }
 
+  async updatePasswordVerified(id: string): Promise<UpdateResult> {
+    return this.userRepository.update(id, {
+      passwordVerifyToken: '',
+    });
+  }
+
   async remove(id: string): Promise<void> {
     await this.userRepository.delete(id);
   }
@@ -141,6 +153,11 @@ export class UserService {
   async saveEmailVerifyToken(id: string, emailVerifyToken: string) {
     await this.userRepository.update(id, { emailVerifyToken });
   }
+
+  async savePasswordVerifyToken(id: string, passwordVerifyToken: string) {
+    await this.userRepository.update(id, { passwordVerifyToken });
+  }
+
   async cryptPassword(password: string): Promise<string> {
     const salt = await bcrypt.genSalt();
     return bcrypt.hash(password, salt);

--- a/back/src/user/user.service.ts
+++ b/back/src/user/user.service.ts
@@ -12,8 +12,13 @@ export class UserService {
   constructor(
     @InjectRepository(User)
     private readonly userRepository: Repository<User>,
+<<<<<<< HEAD
     private connection: DataSource,
   ) {}
+=======
+    private connection: Connection,
+  ) { }
+>>>>>>> 28b1c6e (feat: email verify token saved and verify, add validations)
 
   async findAll(): Promise<User[]> {
     return this.userRepository.find();
@@ -118,6 +123,13 @@ export class UserService {
     return this.userRepository.update(id, user);
   }
 
+  async updateEmailVerified(id: string): Promise<UpdateResult> {
+    return this.userRepository.update(id, {
+      emailVerified: true,
+      emailVerifyToken: '',
+    });
+  }
+
   async remove(id: string): Promise<void> {
     await this.userRepository.delete(id);
   }
@@ -126,6 +138,9 @@ export class UserService {
     await this.userRepository.update(id, { refreshToken });
   }
 
+  async saveEmailVerifyToken(id: string, emailVerifyToken: string) {
+    await this.userRepository.update(id, { emailVerifyToken });
+  }
   async cryptPassword(password: string): Promise<string> {
     const salt = await bcrypt.genSalt();
     return bcrypt.hash(password, salt);


### PR DESCRIPTION
issue #43 에서 언급된 
```
회원가입 발송 이메일 / 비밀번호 찾기시 발송되는 이메일 두군데에서 발생하는 jwt 토큰을

DB에 직접 저장하고 링크를 통해 유저가 엔드포인트에 접속 하였을때 서버쪽에서 검증하는 로직 구현
```

을 구현 하였습니다.

 **emailVerifyToken, passwordVerifyToken** 필드 추가되었습니다. 스키마 업데이트가 필요합니다.
 
1. 각 email.service 함수에서 생성된 토큰을 return
2. auth controller 부분에서 발급된 토큰을 해당 user db에 저장 **emailVerifyToken, passwordVerifyToken** 필드
3. url에서 넘어온 토큰과 db 토근이 일치하는지 확인 (검증 실패시 UnexpectedError 발생)
4. 이메일 확인 / 비밀번호 변경 확인 후 저장되어 있는 토큰값 삭제

확인해야될 부분
- emailVerified 필드가 아직 남아 있고 사용중입니다.
- 임의로 jwt 토큰 값을 수정하여 발생하는 500 에러는 어떻게 처리할것인가?

```
db에 저장되어있는 토큰값을 임의로 aaa로 변경
url에서 임의로 토큰값 쿼리스트링을 aaa로 변경
nest위에서 500에러 발생 (첨부사진 확인 부탁드립니다)
```
![image](https://github.com/woolimi/hypertube/assets/46742040/66d43d55-4f39-47ce-ab2c-37dab21c0953)

위 사항 이외에는 테스트 하였을때 잘 동작합니다. 참고로 user 컨트롤러의 update를 많이 사용하고 있어 검증단계에 에러가 발생해 새로운 코드를 만들었으니 참고 부탁드립니다.
